### PR TITLE
Disable bicubic antialiasing for ONNX/TensorRT

### DIFF
--- a/Convertion_Tensorrt/direct_dinov2_patch.py
+++ b/Convertion_Tensorrt/direct_dinov2_patch.py
@@ -108,12 +108,13 @@ def patch_dinov2_interpolate_method(dinov2_model):
         w_int = max(1, min(w_int, 1000))  # Reasonable bounds
         h_int = max(1, min(h_int, 1000))
         
-        # ONNX-safe interpolation
+        # ONNX-safe interpolation without bicubic antialias kernel
         patch_pos_embed_resized = F.interpolate(
             patch_pos_embed_2d,
             size=(h_int, w_int),
-            mode='bicubic', 
-            align_corners=False
+            mode='bilinear',
+            align_corners=False,
+            antialias=False,
         )
         
         # Reshape back to sequence

--- a/Convertion_Tensorrt/encoders_trt_full.py
+++ b/Convertion_Tensorrt/encoders_trt_full.py
@@ -92,9 +92,11 @@ def _patch_interpolate_pos_encoding(dino_module: nn.Module, patch_size: int = 14
         N_now = L - 1
         gh, gw = _best_factor_pair(N_now)
 
-        # ONNX-safe: specify integer output size, not Tensor scale_factors
-        pe_resized = F.interpolate(pe_4d, size=(int(gh), int(gw)),
-                                   mode="bicubic", align_corners=False)
+        # ONNX-safe: specify integer output size and avoid bicubic/AA kernel
+        pe_resized = F.interpolate(
+            pe_4d, size=(int(gh), int(gw)), mode="bilinear",
+            align_corners=False, antialias=False
+        )
         pe_tokens = pe_resized.permute(0, 2, 3, 1).reshape(1, gh * gw, dim)  # [1, N_now, C]
 
         # Concatenate CLS positional token in front and broadcast over batch

--- a/Convertion_Tensorrt/fix_dinov2_source.py
+++ b/Convertion_Tensorrt/fix_dinov2_source.py
@@ -60,12 +60,12 @@ def patch_dinov2_interpolate_source():
         new_w = int(w0.item()) if torch.is_tensor(w0) else int(w0)
         new_h = max(1, new_h)  # Ensure positive
         new_w = max(1, new_w)  # Ensure positive
-        
+
         patch_pos_embed_2d = patch_pos_embed.reshape(1, grid_size, grid_size, dim).permute(0, 3, 1, 2)
         patch_pos_embed = nn.functional.interpolate(
             patch_pos_embed_2d,
             size=(new_h, new_w),  # Use explicit size instead of scale_factor
-            mode="bicubic",  # Keep bicubic but disable antialias for ONNX compatibility
+            mode="bilinear",  # Use bilinear to avoid unsupported bicubic op
             align_corners=False,
             antialias=False  # Disable antialias to prevent aten::_upsample_bicubic2d_aa
         )'''
@@ -118,7 +118,7 @@ def restore_dinov2_original():
         patch_pos_embed = nn.functional.interpolate(
             patch_pos_embed_2d,
             size=(new_h, new_w),  # Use explicit size instead of scale_factor
-            mode="bicubic",  # Keep bicubic but disable antialias for ONNX compatibility
+            mode="bilinear",  # Use bilinear to avoid unsupported bicubic op
             align_corners=False,
             antialias=False  # Disable antialias to prevent aten::_upsample_bicubic2d_aa
         )'''

--- a/Convertion_Tensorrt/patch_dinov2_for_onnx.py
+++ b/Convertion_Tensorrt/patch_dinov2_for_onnx.py
@@ -57,12 +57,13 @@ def patch_dinov2_interpolate_pos_encoding(dinov2_model):
         w_int = max(1, w_int)
         h_int = max(1, h_int)
         
-        # Interpolate to target size with explicit parameters
+        # Interpolate to target size with explicit parameters, avoiding bicubic AA
         patch_pos_embed_resized = F.interpolate(
             patch_pos_embed_2d,
             size=(h_int, w_int),  # Use integer tuple, not scale_factors
-            mode='bicubic',
-            align_corners=False
+            mode='bilinear',
+            align_corners=False,
+            antialias=False,
         )
         
         # Reshape back to sequence

--- a/Convertion_Tensorrt/patch_dinov2_source.py
+++ b/Convertion_Tensorrt/patch_dinov2_source.py
@@ -68,12 +68,13 @@ def apply_global_dinov2_patch():
             w_int = max(1, w_int)
             h_int = max(1, h_int)
             
-            # Use ONNX-safe interpolation with integer size
+            # Use ONNX-safe interpolation with integer size, avoiding bicubic AA
             patch_pos_embed_resized = F.interpolate(
                 patch_pos_embed_2d,
                 size=(h_int, w_int),
-                mode='bicubic',
-                align_corners=False
+                mode='bilinear',
+                align_corners=False,
+                antialias=False,
             )
             
             # Reshape back

--- a/imcui/hloc/extract_features.py
+++ b/imcui/hloc/extract_features.py
@@ -487,7 +487,7 @@ def extract(model, image_0, conf):
                 image.shape[-2:],
             )
         )
-        image = F.resize(image, size=size_new, antialias=True)
+        image = F.resize(image, size=size_new, antialias=False)
         input_ = image.to(device, non_blocking=True)[None]
         data = {
             "image": input_,

--- a/imcui/hloc/match_dense.py
+++ b/imcui/hloc/match_dense.py
@@ -907,7 +907,7 @@ def match(model, path_0, path_1, conf):
                 image.shape[-2:],
             )
         )
-        image = F.resize(image, size=size_new, antialias=True)
+        image = F.resize(image, size=size_new, antialias=False)
         scale = np.array(size) / np.array(size_new)[::-1]
         return image, scale
 

--- a/imcui/hloc/matchers/duster.py
+++ b/imcui/hloc/matchers/duster.py
@@ -44,12 +44,12 @@ class Duster(BaseModel):
         imsize = h
         if not ((h % self.vit_patch_size) == 0):
             imsize = int(self.vit_patch_size * round(h / self.vit_patch_size, 0))
-            img = tfm.functional.resize(img, imsize, antialias=True)
+            img = tfm.functional.resize(img, imsize, antialias=False)
 
         _, new_h, new_w = img.shape
         if not ((new_w % self.vit_patch_size) == 0):
             safe_w = int(self.vit_patch_size * round(new_w / self.vit_patch_size, 0))
-            img = tfm.functional.resize(img, (new_h, safe_w), antialias=True)
+            img = tfm.functional.resize(img, (new_h, safe_w), antialias=False)
 
         img = self.normalize(img).unsqueeze(0)
 

--- a/imcui/third_party/MatchAnything/third_party/ROMA/roma/models/croco/pos_embed.py
+++ b/imcui/third_party/MatchAnything/third_party/ROMA/roma/models/croco/pos_embed.py
@@ -93,7 +93,7 @@ def interpolate_pos_embed(model, checkpoint_model):
             pos_tokens = pos_embed_checkpoint[:, num_extra_tokens:]
             pos_tokens = pos_tokens.reshape(-1, orig_size, orig_size, embedding_size).permute(0, 3, 1, 2)
             pos_tokens = torch.nn.functional.interpolate(
-                pos_tokens, size=(new_size, new_size), mode='bicubic', align_corners=False, antialias=False)
+                pos_tokens, size=(new_size, new_size), mode='bilinear', align_corners=False, antialias=False)
             pos_tokens = pos_tokens.permute(0, 2, 3, 1).flatten(1, 2)
             new_pos_embed = torch.cat((extra_tokens, pos_tokens), dim=1)
             checkpoint_model['pos_embed'] = new_pos_embed

--- a/imcui/third_party/MatchAnything/third_party/ROMA/roma/models/dust3r/utils/image.py
+++ b/imcui/third_party/MatchAnything/third_party/ROMA/roma/models/dust3r/utils/image.py
@@ -52,7 +52,8 @@ def _resize_pil_image(img, long_edge_size):
     if S > long_edge_size:
         interp = PIL.Image.LANCZOS
     elif S <= long_edge_size:
-        interp = PIL.Image.BICUBIC
+        # Use bilinear to avoid bicubic during ONNX export
+        interp = PIL.Image.BILINEAR
     new_size = tuple(int(round(x*long_edge_size/S)) for x in img.size)
     return img.resize(new_size, interp)
 

--- a/imcui/third_party/MatchAnything/third_party/ROMA/roma/utils/utils.py
+++ b/imcui/third_party/MatchAnything/third_party/ROMA/roma/utils/utils.py
@@ -35,8 +35,10 @@ def resize_and_padding(img, resize, padding=True):
     resize: aim (h, w)
     """
     c, h_org, w_org = img.shape
-    # img_resized = transforms.Resize(resize, InterpolationMode.BILINEAR)(img)
-    img_resized = transforms.Resize(resize, InterpolationMode.BICUBIC)(img)
+    # Use bilinear resize without antialiasing for ONNX compatibility
+    img_resized = transforms.Resize(
+        resize, InterpolationMode.BILINEAR, antialias=False
+    )(img)
 
     if padding:
         img_padded = torch.zeros((c, max(resize), max(resize)), device=img.device)
@@ -268,9 +270,10 @@ class TupleResizeNearestExact:
 
 
 class TupleResize(object):
-    def __init__(self, size, mode=InterpolationMode.BICUBIC):
+    def __init__(self, size, mode=InterpolationMode.BILINEAR):
         self.size = size
-        self.resize = transforms.Resize(size, mode)
+        # Disable antialias for ONNX compatibility
+        self.resize = transforms.Resize(size, mode, antialias=False)
     def __call__(self, im_tuple):
         return [self.resize(im) for im in im_tuple]
 


### PR DESCRIPTION
## Summary
- swap bicubic resizes for bilinear and disable antialiasing in ROMA utilities
- update DINOv2 TensorRT patches to use bilinear interpolation without antialiasing

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68baaaf8c4308322a21f8c56271a90ac