### PR TITLE
Add dynamic TensorRT export and runner utilities

### DIFF
--- a/Convertion_Tensorrt_new/accurate_matchanything_trt_dyn.py
+++ b/Convertion_Tensorrt_new/accurate_matchanything_trt_dyn.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Accurate MatchAnything (ROMA-style) for ONNX/TensorRT (dynamic HxW).
+- Pads inside the graph to the next multiple of encoder.patch (e.g., 16).
+- Returns dense fields: warp_c [B,Ha,Wa,2], cert_c [B,Ha,Wa]
+- Also returns: valid_mask [B,Ha,Wa] (1 real, 0 padded), coarse_stride [1] (float)
+- No in-graph thresholding; host filters/top-K.
+"""
+
+from typing import Dict, Tuple
+import sys
+from pathlib import Path
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+# --- allow importing modules from your old folder (Convertion_Tensorrt) ---
+_THIS_DIR = Path(__file__).resolve().parent
+_OLD_DIR = _THIS_DIR.parent / "Convertion_Tensorrt"
+if _OLD_DIR.exists() and str(_OLD_DIR) not in sys.path:
+    sys.path.insert(0, str(_OLD_DIR))
+# -------------------------------------------------------------------------
+
+from encoders_trt_full import CNNandDinov2TRT
+from gp_trt import GPMatchEncoderTRT
+
+
+def _pad_to_multiple(x: torch.Tensor, mult: int) -> Tuple[torch.Tensor, int, int]:
+    """Right/bottom pad to make H,W multiples of mult. Return (padded, pad_h, pad_w)."""
+    B, C, H, W = x.shape
+    pad_h = (mult - (H % mult)) % mult
+    pad_w = (mult - (W % mult)) % mult
+    if pad_h == 0 and pad_w == 0:
+        return x, 0, 0
+    # pad format: (left, right, top, bottom)
+    return F.pad(x, (0, pad_w, 0, pad_h)), pad_h, pad_w
+
+
+class AccurateMatchAnythingTRT(nn.Module):
+    def __init__(self, amp: bool = False):
+        super().__init__()
+        self.encoder = CNNandDinov2TRT(amp=amp)  # has .patch (your enc asserts 16)
+        self.matcher = GPMatchEncoderTRT(beta=10.0)  # ROMA-style GP matcher
+
+    def forward(
+        self, image0: torch.Tensor, image1: torch.Tensor
+    ) -> Dict[str, torch.Tensor]:
+        """
+        Inputs: image0, image1 -> [B,3,H,W] RGB float in [0,1], any H,W
+        Outputs:
+            warp_c        [B,Ha,Wa,2]  coarse coords (x,y) in img1
+            cert_c        [B,Ha,Wa]
+            valid_mask    [B,Ha,Wa]    1 for real image area, 0 for padded
+            coarse_stride [1]  (float) encoder patch/stride (e.g., 16.)
+        """
+        B, C, H, W = image0.shape
+        patch = int(getattr(self.encoder, "patch", 16))
+
+        # RGB->Gray inside graph (ONNX-friendly)
+        img0_gray = (
+            0.299 * image0[:, 0:1] + 0.587 * image0[:, 1:2] + 0.114 * image0[:, 2:3]
+        )
+        img1_gray = (
+            0.299 * image1[:, 0:1] + 0.587 * image1[:, 1:2] + 0.114 * image1[:, 2:3]
+        )
+
+        # Pad to multiple-of-patch
+        img0p, _, _ = _pad_to_multiple(img0_gray, patch)
+        img1p, _, _ = _pad_to_multiple(img1_gray, patch)
+
+        # Coarse features (stride=patch)
+        feat0 = self.encoder(img0p)["coarse"]  # [B,Cc,Ha,Wa]
+        feat1 = self.encoder(img1p)["coarse"]  # [B,Cc,Ha,Wa]
+
+        # Dense matching
+        warp_c, cert_c = self.matcher(feat0, feat1)  # [B,Ha,Wa,2], [B,Ha,Wa]
+        _, Ha, Wa, _ = warp_c.shape
+
+        # Valid coarse mask for original extent (ignore padded coarse cells)
+        yy = torch.arange(Ha, device=warp_c.device).view(1, Ha, 1).float()
+        xx = torch.arange(Wa, device=warp_c.device).view(1, 1, Wa).float()
+        valid_y = (yy * patch) < float(H)
+        valid_x = (xx * patch) < float(W)
+        valid_mask = (valid_y & valid_x).to(cert_c.dtype).expand(B, Ha, Wa)
+
+        # Stride as tensor (export-friendly)
+        coarse_stride = torch.tensor(
+            [float(patch)], device=warp_c.device, dtype=warp_c.dtype
+        )
+
+        return {
+            "warp_c": warp_c,
+            "cert_c": cert_c,
+            "valid_mask": valid_mask,
+            "coarse_stride": coarse_stride,
+        }

--- a/Convertion_Tensorrt_new/export_dense_onnx.py
+++ b/Convertion_Tensorrt_new/export_dense_onnx.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Export MatchAnything (ROMA) to ONNX with dense outputs (warp_c, cert_c).
+
+Notes:
+  • Inputs:  image0, image1   -> [B,3,H,W], float32 in [0,1]
+  • Outputs: warp_c            -> [B,Ha,Wa,2]  (coarse grid coords in image1, Ha=H/14, Wa=W/14)
+            cert_c            -> [B,Ha,Wa]
+  • Dynamic axes: B, H, W, Ha, Wa
+  • No in-graph thresholding, no variable-length lists.
+"""
+
+import os
+import inspect
+import torch
+import onnx
+
+from Convertion_Tensorrt_new.accurate_matchanything_trt_dyn import (
+    AccurateMatchAnythingTRT,
+)
+
+
+# Optional: your weight mapping loader (if available)
+def _try_load_weights(model, ckpt_path: str):
+    if ckpt_path and os.path.exists(ckpt_path):
+        try:
+            # Your full unified loader module name if present in your repo
+            from unified_weight_loader_complete import apply_unified_weight_loading
+
+            model_state = model.state_dict()
+            loadable = apply_unified_weight_loading(
+                ckpt_path, model_state, load_dinov2_components=True
+            )
+            missing, unexpected = model.load_state_dict(loadable, strict=False)
+            print(
+                f"[WEIGHTS] Loaded={len(loadable)}, missing={len(missing)}, unexpected={len(unexpected)}"
+            )
+        except Exception as e:
+            print(f"[WEIGHTS] Failed unified loader: {e}")
+            print(
+                "[WEIGHTS] Proceeding WITHOUT weights (random init) — expect low scores."
+            )
+    else:
+        print("[WEIGHTS] No checkpoint file given; continuing without weights.")
+
+
+def export_onnx(onnx_path: str, ckpt: str = "", H: int = 840, W: int = 840):
+    device = "cpu"
+    model = AccurateMatchAnythingTRT(amp=False).to(device).eval()
+    _try_load_weights(model, ckpt)
+
+    # Dummy inputs — pick multiples of 14 (e.g., 840 = 60*14)
+    x0 = torch.rand(1, 3, H, W, device=device)
+    x1 = torch.rand(1, 3, H, W, device=device)
+
+    # Dry run
+    with torch.inference_mode():
+        out = model(x0, x1)
+        print("Dry run:", out["warp_c"].shape, out["cert_c"].shape)
+
+    dynamic_axes = {
+        "image0": {"0": "B", "2": "H", "3": "W"},
+        "image1": {"0": "B", "2": "H", "3": "W"},
+        "warp_c": {"0": "B", "1": "Ha", "2": "Wa"},
+        "cert_c": {"0": "B", "1": "Ha", "2": "Wa"},
+    }
+
+    export_kwargs = dict(
+        input_names=["image0", "image1"],
+        output_names=["warp_c", "cert_c"],
+        dynamic_axes=dynamic_axes,
+        opset_version=17,
+        do_constant_folding=True,
+        verbose=False,
+    )
+    if "use_external_data_format" in inspect.signature(torch.onnx.export).parameters:
+        export_kwargs["use_external_data_format"] = True
+
+    os.makedirs(os.path.dirname(onnx_path) or ".", exist_ok=True)
+    torch.onnx.export(model, (x0, x1), onnx_path, **export_kwargs)
+    print(f"[ONNX] Saved -> {onnx_path}")
+
+    # (Optional) consolidate external data if created by exporter
+    try:
+        model_proto = onnx.load(onnx_path, load_external_data=True)
+        onnx.save_model(model_proto, onnx_path, save_as_external_data=True)
+    except Exception as e:
+        print(f"[ONNX] External data consolidation skipped: {e}")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--onnx", default="out/matchanything_dense.onnx")
+    ap.add_argument("--ckpt", default="")
+    ap.add_argument("--H", type=int, default=840, help="Multiple of 14")
+    ap.add_argument("--W", type=int, default=840, help="Multiple of 14")
+    args = ap.parse_args()
+    export_onnx(args.onnx, args.ckpt, args.H, args.W)

--- a/Convertion_Tensorrt_new/export_dynamic_onnx_unified.py
+++ b/Convertion_Tensorrt_new/export_dynamic_onnx_unified.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""
+Export dynamic ONNX for MatchAnything with unified weight loading & full stats.
+
+Outputs (dense, no filtering):
+  - warp_c        [B,Ha,Wa,2]
+  - cert_c        [B,Ha,Wa]
+  - valid_mask    [B,Ha,Wa]
+  - coarse_stride [1]  (float)
+
+Dynamic axes for B,H,W,Ha,Wa. Compatible with TensorRT dynamic profiles.
+"""
+
+import os
+import re
+import inspect
+import sys
+import tempfile
+from contextlib import contextmanager, redirect_stdout, redirect_stderr
+from pathlib import Path
+from typing import Dict, List, Tuple
+import numpy as np
+import torch
+import torch.nn.functional as F
+import onnx
+
+# Optional timm (for DINOv2 backfill). If missing, we continue.
+try:
+    import timm
+except Exception:
+    timm = None
+
+_THIS_DIR = Path(__file__).resolve().parent
+if str(_THIS_DIR) not in os.sys.path:
+    os.sys.path.insert(0, str(_THIS_DIR))
+
+from accurate_matchanything_trt_dyn import AccurateMatchAnythingTRT
+
+
+# ---------------------------------------------------------------------
+# Low-level (C/C++) stdout/stderr silencer (captures libtorch/ONNX prints)
+# ---------------------------------------------------------------------
+@contextmanager
+def silence_stdio_c(stdout=True, stderr=True):
+    """
+    Temporarily redirect OS-level file descriptors for stdout/stderr to a
+    temporary file so C/C++ prints (libtorch/JIT/ONNX) are hidden.
+
+    NOTE: Python-level redirect_* only captures Python writes; C++ writes need
+    fd redirection (os.dup2) as described by pybind11 & others.
+    """
+    fds = []
+    backups = []
+    tmp = None
+    try:
+        if not (stdout or stderr):
+            yield
+            return
+
+        # Flush Python streams so we don't lose ordering
+        sys.stdout.flush()
+        sys.stderr.flush()
+
+        tmp = tempfile.TemporaryFile(mode="w+b")
+        if stdout:
+            backups.append((1, os.dup(1)))
+            fds.append(1)
+        if stderr:
+            backups.append((2, os.dup(2)))
+            fds.append(2)
+
+        for fd in fds:
+            os.dup2(tmp.fileno(), fd)
+
+        yield
+    finally:
+        try:
+            # Restore original fds
+            for fd, bk in backups:
+                os.dup2(bk, fd)
+                os.close(bk)
+        finally:
+            if tmp is not None:
+                tmp.close()
+
+
+# -----------------------------
+# Unified weight loading
+# -----------------------------
+def create_comprehensive_mapping_rules() -> List[Tuple[re.Pattern, str]]:
+    return [
+        (re.compile(r"^module\."), ""),
+        (re.compile(r"^_orig_mod\."), ""),
+        (re.compile(r"^matcher\.model\.decoder\.embedding_decoder\."), "encoder.dino."),
+        (re.compile(r"^embedding_decoder\."), "encoder.dino."),
+        (re.compile(r"^decoder\.embedding_decoder\."), "encoder.dino."),
+        (re.compile(r"^matcher\.model\.encoder\.cnn\.layers\."), "encoder.layers."),
+        (re.compile(r"^matcher\.model\.encoder\.cnn\."), "encoder."),
+        (re.compile(r"^matcher\.model\.encoder\."), "encoder."),
+        (re.compile(r"^matcher\.model\.decoder\."), "matcher."),
+        (re.compile(r"^matcher\.model\."), ""),
+        (re.compile(r"^matcher\."), ""),
+        (re.compile(r"^model\."), ""),
+        (re.compile(r"^backbone\."), "encoder.dino."),
+        (re.compile(r"^vit\."), "encoder.dino."),
+        (re.compile(r"^dino\."), "encoder.dino."),
+        (re.compile(r"^encoder\.vit\."), "encoder.dino."),
+        (re.compile(r"^encoder\.backbone\."), "encoder.dino."),
+        (re.compile(r"^encoder\.dino\."), "encoder.dino."),
+        (re.compile(r"^encoder\."), "encoder."),
+    ]
+
+
+def fix_dinov2_block_structure(
+    weights_dict: Dict[str, torch.Tensor],
+) -> Dict[str, torch.Tensor]:
+    """Convert 'encoder.dino.blocks.N.*' -> 'encoder.dino.blocks.0.N.*' for BlockChunk."""
+    fixed = {}
+    for k, v in weights_dict.items():
+        if k.startswith("encoder.dino.blocks."):
+            parts = k.split(".")
+            if len(parts) >= 4 and parts[3].isdigit():
+                blk = parts[3]
+                if len(parts) >= 5 and parts[4].isdigit():
+                    fixed[k] = v
+                else:
+                    new_key = ".".join(parts[:3] + ["0", blk] + parts[4:])
+                    fixed[new_key] = v
+                    print(f"[LOAD] BlockChunk fix: {k} -> {new_key}")
+            else:
+                fixed[k] = v
+        else:
+            fixed[k] = v
+    return fixed
+
+
+def resize_positional_embedding(
+    pos_embed: torch.Tensor, target_size: int
+) -> torch.Tensor:
+    if pos_embed.shape[1] == target_size:
+        print(f"[LOAD] pos_embed already {tuple(pos_embed.shape)}")
+        return pos_embed
+    print(
+        f"[LOAD] Resize pos_embed {tuple(pos_embed.shape)} -> [1,{target_size},{pos_embed.shape[2]}]"
+    )
+    cls = pos_embed[:, 0:1, :]
+    spatial = pos_embed[:, 1:, :]
+    nsp = spatial.shape[1]
+    og = int(np.sqrt(nsp))
+    assert og * og == nsp, f"pos_embed spatial tokens not square: {nsp}"
+    tg_spatial = target_size - 1
+    tg = int(np.sqrt(tg_spatial))
+    assert tg * tg == tg_spatial, f"target size {target_size} not square+1"
+    D = spatial.shape[2]
+    spatial_2d = spatial.reshape(1, og, og, D).permute(0, 3, 1, 2)  # [1,D,H,W]
+    resized = F.interpolate(
+        spatial_2d, size=(tg, tg), mode="bilinear", align_corners=False
+    )
+    resized = resized.permute(0, 2, 3, 1).reshape(1, tg_spatial, D)
+    out = torch.cat([cls, resized], dim=1)
+    return out
+
+
+def load_dinov2_components(
+    model_state: Dict[str, torch.Tensor],
+) -> Dict[str, torch.Tensor]:
+    """Optional fill-ins from official DINOv2 timm weights."""
+    out = {}
+    if timm is None:
+        print("[LOAD] timm not available; skipping DINOv2 backfill")
+        return out
+    try:
+        print("[LOAD] Loading DINOv2 (timm) for missing components...")
+        dinom = timm.create_model("vit_large_patch14_dinov2.lvd142m", pretrained=True)
+        official = dinom.state_dict()
+
+        if "encoder.dino.pos_embed" in model_state and "pos_embed" in official:
+            pos = official["pos_embed"]
+            tgt = model_state["encoder.dino.pos_embed"]
+            if pos.shape != tgt.shape:
+                pos = resize_positional_embedding(pos, tgt.shape[1])
+            out["encoder.dino.pos_embed"] = pos
+            print(f"[LOAD] +pos_embed {tuple(pos.shape)}")
+
+        # If the ckpt didn't have these at all, synthesize or copy from timm
+        if "encoder.dino.cls_token" in model_state:
+            out["encoder.dino.cls_token"] = official.get(
+                "cls_token", torch.zeros_like(model_state["encoder.dino.cls_token"])
+            )
+            print(f"[LOAD] +cls_token {tuple(out['encoder.dino.cls_token'].shape)}")
+        if "encoder.dino.mask_token" in model_state:
+            out["encoder.dino.mask_token"] = official.get(
+                "mask_token", torch.zeros_like(model_state["encoder.dino.mask_token"])
+            )
+            src = "timm" if "mask_token" in official else "synthesized zeros"
+            print(
+                f"[LOAD] +mask_token ({src}) {tuple(out['encoder.dino.mask_token'].shape)}"
+            )
+
+        need_patch = any(
+            k.startswith("encoder.dino.patch_embed.") for k in model_state.keys()
+        )
+        if need_patch:
+            for k, v in official.items():
+                if k.startswith("patch_embed."):
+                    nk = f"encoder.dino.{k}"
+                    if nk in model_state:
+                        out[nk] = v
+                        print(f"[LOAD] +{nk} {tuple(v.shape)}")
+
+        # If final LayerNorm params are totally missing, mirror from official or zeros
+        if (
+            "encoder.dino.norm.weight" in model_state
+            and "encoder.dino.norm.weight" not in out
+        ):
+            out["encoder.dino.norm.weight"] = official.get(
+                "norm.weight", torch.ones_like(model_state["encoder.dino.norm.weight"])
+            )
+            print(
+                f"[LOAD] +encoder.dino.norm.weight {tuple(out['encoder.dino.norm.weight'].shape)}"
+            )
+        if (
+            "encoder.dino.norm.bias" in model_state
+            and "encoder.dino.norm.bias" not in out
+        ):
+            out["encoder.dino.norm.bias"] = official.get(
+                "norm.bias", torch.zeros_like(model_state["encoder.dino.norm.bias"])
+            )
+            print(
+                f"[LOAD] +encoder.dino.norm.bias {tuple(out['encoder.dino.norm.bias'].shape)}"
+            )
+
+    except Exception as e:
+        print(f"[LOAD] DINOv2 backfill failed: {e}")
+    return out
+
+
+def load_missing_dinov2_blocks(
+    model_state: Dict[str, torch.Tensor], existing: Dict[str, torch.Tensor]
+) -> Dict[str, torch.Tensor]:
+    """Fill missing transformer blocks from official DINOv2 (wrap-around if needed)."""
+    out = {}
+    if timm is None:
+        print("[LOAD] timm not available; skipping missing-block fill")
+        return out
+    try:
+        print("[LOAD] Filling missing DINOv2 blocks from timm...")
+        dinom = timm.create_model("vit_large_patch14_dinov2.lvd142m", pretrained=True)
+        official = dinom.state_dict()
+
+        need, have = set(), set()
+        for k in model_state.keys():
+            if k.startswith("encoder.dino.blocks.0.") and len(k.split(".")) >= 5:
+                blk = k.split(".")[4]
+                if blk.isdigit():
+                    need.add(int(blk))
+        for k in existing.keys():
+            if k.startswith("encoder.dino.blocks.0.") and len(k.split(".")) >= 5:
+                blk = k.split(".")[4]
+                if blk.isdigit():
+                    have.add(int(blk))
+        miss = need - have
+        print(f"[LOAD] Need blocks: {sorted(need)}")
+        print(f"[LOAD] Have blocks: {sorted(have)}")
+        print(f"[LOAD] Missing:     {sorted(miss)}")
+
+        for mb in sorted(miss):
+            src = mb % 24  # wrap if needed
+            for ok, ov in official.items():
+                if ok.startswith(f"blocks.{src}."):
+                    comps = ok.split(".")[2:]  # drop 'blocks.N'
+                    nk = f"encoder.dino.blocks.0.{mb}." + ".".join(comps)
+                    if nk in model_state:
+                        out[nk] = ov
+        print(f"[LOAD] Added {len(out)} missing block params")
+    except Exception as e:
+        print(f"[LOAD] Missing-block fill failed: {e}")
+    return out
+
+
+def apply_unified_weight_loading(
+    checkpoint_path: str,
+    model_state: Dict[str, torch.Tensor],
+    use_dinov2_backfill: bool = True,
+) -> Dict[str, torch.Tensor]:
+    print(f"[LOAD] Reading checkpoint: {checkpoint_path}")
+    try:
+        raw = torch.load(checkpoint_path, map_location="cpu")
+        ckpt_state = raw.get("state_dict", raw)
+    except Exception as e:
+        print(f"[LOAD] ERROR loading checkpoint: {e}")
+        return {}
+
+    print(f"[LOAD] CKPT keys: {len(ckpt_state)}")
+    print(f"[LOAD] Model expects keys: {len(model_state)}")
+
+    # Step 1: map keys
+    rules = create_comprehensive_mapping_rules()
+    mapped = {}
+    for k, v in ckpt_state.items():
+        nk = k
+        for pat, rep in rules:
+            nk = pat.sub(rep, nk)
+        mapped[nk] = v
+    print(f"[LOAD] After mapping: {len(mapped)}")
+
+    # Step 2: DINO BlockChunk structure
+    mapped = fix_dinov2_block_structure(mapped)
+
+    # Step 3: optional backfill from official DINOv2
+    if use_dinov2_backfill:
+        back = load_dinov2_components(model_state)
+        mapped.update(back)
+
+    # Step 4: direct matches
+    loadable: Dict[str, torch.Tensor] = {}
+    for mk, mv in model_state.items():
+        if mk in mapped and mapped[mk].shape == mv.shape:
+            loadable[mk] = mapped[mk]
+    print(f"[LOAD] Direct matches: {len(loadable)}")
+
+    # Step 5: fill missing blocks
+    if use_dinov2_backfill:
+        add_blocks = load_missing_dinov2_blocks(model_state, loadable)
+        loadable.update(add_blocks)
+        print(f"[LOAD] After missing-block fill: {len(loadable)}")
+
+    # Step 6: final backfill for qkv.bias (paramwise copy by block index)
+    if use_dinov2_backfill and timm is not None:
+        try:
+            dinom = timm.create_model(
+                "vit_large_patch14_dinov2.lvd142m", pretrained=True
+            )
+            official = dinom.state_dict()
+            for b in range(24):
+                mk = f"encoder.dino.blocks.0.{b}.attn.qkv.bias"
+                ok = f"blocks.{b}.attn.qkv.bias"
+                if (
+                    mk in model_state
+                    and mk not in loadable
+                    and ok in official
+                    and official[ok].shape == model_state[mk].shape
+                ):
+                    loadable[mk] = official[ok]
+                    print(f"[LOAD] +paramwise {mk}  (from {ok})")
+            print(f"[LOAD] After paramwise fill: {len(loadable)}")
+        except Exception as e:
+            print(f"[LOAD] Paramwise fill failed: {e}")
+
+    # Report
+    loaded_cnt = len(loadable)
+    total_cnt = len(model_state)
+    pct = 100.0 * loaded_cnt / max(1, total_cnt)
+    print("[LOAD] === SUMMARY ===")
+    print(f"[LOAD] Loaded tensors: {loaded_cnt} / {total_cnt}  ({pct:.1f}%)")
+
+    # DINO block coverage
+    blocks_loaded = set()
+    for k in loadable.keys():
+        if k.startswith("encoder.dino.blocks.0.") and len(k.split(".")) >= 5:
+            b = k.split(".")[4]
+            if b.isdigit():
+                blocks_loaded.add(int(b))
+    print(f"[LOAD] DINOv2 blocks loaded: {len(blocks_loaded)}/24")
+
+    if loaded_cnt >= 0.95 * total_cnt:
+        print("[LOAD] ✅ SUCCESS: >95% loaded")
+    elif loaded_cnt >= 0.8 * total_cnt:
+        print("[LOAD] ⚠️  WARNING: 80–95% loaded")
+    else:
+        print("[LOAD] ❌ ERROR: <80% loaded")
+
+    return loadable
+
+
+# -----------------------------
+# Export
+# -----------------------------
+def export_onnx(
+    onnx_path: str,
+    ckpt: str = "",
+    H: int = 768,
+    W: int = 1024,
+    use_dinov2_backfill: bool = True,
+    verbose_export: bool = False,
+    silence_cpp: bool = True,
+):
+    # Keep logs quieter unless asked
+    os.environ.pop("PYTORCH_ONNX_VERBOSE", None)
+    os.environ.pop("PYTORCH_JIT_LOG_LEVEL", None)
+    os.environ.pop("TORCH_LOGS", None)
+
+    device = "cpu"
+    model = AccurateMatchAnythingTRT(amp=False).to(device).eval()
+
+    # Load weights
+    if ckpt and os.path.exists(ckpt):
+        ms = model.state_dict()
+        loadable = apply_unified_weight_loading(ckpt, ms, use_dinov2_backfill)
+        missing, unexpected = model.load_state_dict(loadable, strict=False)
+        print(
+            f"[LOAD] load_state_dict -> loaded={len(loadable)}, missing={len(missing)}, unexpected={len(unexpected)}"
+        )
+        if missing:
+            print("[LOAD] --- Missing keys ---")
+            for k in sorted(missing):
+                print("   ", k)
+        if unexpected:
+            print("[LOAD] --- Unexpected keys ---")
+            for k in sorted(unexpected):
+                print("   ", k)
+    else:
+        print(
+            "[LOAD] No checkpoint provided or file missing; continuing with random init (low scores)."
+        )
+
+    # Dummy input
+    x0 = torch.rand(1, 3, H, W, device=device)
+    x1 = torch.rand(1, 3, H, W, device=device)
+
+    # Dry run
+    with torch.inference_mode():
+        out = model(x0, x1)
+        print(
+            "Dry run:",
+            "warp_c",
+            tuple(out["warp_c"].shape),
+            "cert_c",
+            tuple(out["cert_c"].shape),
+            "valid_mask",
+            tuple(out["valid_mask"].shape),
+            "coarse_stride",
+            tuple(out["coarse_stride"].shape),
+        )
+
+    out_path = Path(onnx_path).expanduser().resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    dynamic_axes = {
+        "image0": {"0": "B", "2": "H", "3": "W"},
+        "image1": {"0": "B", "2": "H", "3": "W"},
+        "warp_c": {"0": "B", "1": "Ha", "2": "Wa"},
+        "cert_c": {"0": "B", "1": "Ha", "2": "Wa"},
+        "valid_mask": {"0": "B", "1": "Ha", "2": "Wa"},
+        "coarse_stride": {"0": "one"},
+    }
+
+    kwargs = dict(
+        input_names=["image0", "image1"],
+        output_names=["warp_c", "cert_c", "valid_mask", "coarse_stride"],
+        dynamic_axes=dynamic_axes,
+        opset_version=17,
+        do_constant_folding=True,
+        verbose=bool(verbose_export),
+        training=torch.onnx.TrainingMode.EVAL,
+    )
+    if "use_external_data_format" in inspect.signature(torch.onnx.export).parameters:
+        kwargs["use_external_data_format"] = True  # safer for very large models
+
+    # Export with both Python-level and OS-level silencing
+    try:
+        with (
+            redirect_stdout(open(os.devnull, "w")),
+            redirect_stderr(open(os.devnull, "w")),
+        ):
+            ctx = (
+                silence_stdio_c(stdout=True, stderr=True)
+                if silence_cpp
+                else contextmanager(lambda: (yield))()
+            )
+            with ctx:
+                torch.onnx.export(model, (x0, x1), str(out_path), **kwargs)
+    except Exception as e:
+        # Make sure the error is visible even if we were silencing
+        sys.stdout.flush()
+        sys.stderr.flush()
+        print(f"[ONNX] EXPORT FAILED: {e}")
+        raise
+
+    # Verify file exists and is readable
+    if not out_path.exists():
+        raise FileNotFoundError(f"[ONNX] Expected file not found: {out_path}")
+
+    size_mb = out_path.stat().st_size / (1024 * 1024.0)
+    print(f"[ONNX] Saved -> {out_path}  ({size_mb:.1f} MB)")
+
+    # Load with onnx to sanity-check
+    try:
+        mp = onnx.load(str(out_path), load_external_data=True)
+        print(
+            f"[ONNX] Model loaded OK: ir_version={mp.ir_version}, opsets={[ (o.domain,o.version) for o in mp.opset_import ]}"
+        )
+    except Exception as e:
+        print(f"[ONNX] WARNING: onnx.load failed: {e}")
+
+    return str(out_path)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser(
+        description="Export dynamic ONNX with unified weight loading"
+    )
+    ap.add_argument("--onnx", default="out/matchanything_dense_dynamic.onnx")
+    ap.add_argument(
+        "--ckpt",
+        default="/home/mathias/MatchAnything/imcui/third_party/MatchAnything/weights/matchanything_roma.ckpt",
+    )
+    ap.add_argument("--H", type=int, default=768)
+    ap.add_argument("--W", type=int, default=1024)
+    ap.add_argument(
+        "--no_dinov2_backfill", action="store_true", help="Disable DINOv2 timm backfill"
+    )
+    ap.add_argument(
+        "--verbose_export",
+        action="store_true",
+        help="ONNX exporter verbose graph print",
+    )
+    ap.add_argument(
+        "--no_silence_cpp",
+        action="store_true",
+        help="Do not silence C++ stdout/stderr during export",
+    )
+    args = ap.parse_args()
+
+    export_onnx(
+        onnx_path=args.onnx,
+        ckpt=args.ckpt,
+        H=args.H,
+        W=args.W,
+        use_dinov2_backfill=not args.no_dinov2_backfill,
+        verbose_export=args.verbose_export,
+        silence_cpp=not args.no_silence_cpp,
+    )

--- a/Convertion_Tensorrt_new/run_trt_dense.py
+++ b/Convertion_Tensorrt_new/run_trt_dense.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+import numpy as np
+import cv2
+import torch
+import tensorrt as trt
+
+TRT_LOGGER = trt.Logger(trt.Logger.INFO)
+
+
+def ceil_mul14(x):  # smallest multiple of 14 >= x
+    return ((x + 13) // 14) * 14
+
+
+def load_rgb_tensor(path, size=None):
+    """Read BGR, -> RGB float32 [0,1], resize to (size,size) if given (rounded up to multiple-of-14)."""
+    img_bgr = cv2.imread(str(path), cv2.IMREAD_COLOR)
+    if img_bgr is None:
+        raise FileNotFoundError(path)
+    if size is not None:
+        size14 = ceil_mul14(size)
+        img_bgr = cv2.resize(
+            img_bgr, (size14, size14), interpolation=cv2.INTER_LANCZOS4
+        )
+    img_rgb = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0
+    t = (
+        torch.from_numpy(np.transpose(img_rgb, (2, 0, 1))[None, ...])
+        .contiguous()
+        .float()
+    )
+    return t, img_bgr
+
+
+def draw_matches_side_by_side(imgA, imgB, ptsA, ptsB, conf=None, max_draw=1000):
+    A = imgA.copy()
+    B = imgB.copy()
+    if A.ndim == 2:
+        A = cv2.cvtColor(A, cv2.COLOR_GRAY2BGR)
+    if B.ndim == 2:
+        B = cv2.cvtColor(B, cv2.COLOR_GRAY2BGR)
+    H = max(A.shape[0], B.shape[0])
+    canvas = np.zeros((H, A.shape[1] + B.shape[1], 3), dtype=np.uint8)
+    canvas[: A.shape[0], : A.shape[1]] = A
+    canvas[: B.shape[0], A.shape[1] : A.shape[1] + B.shape[1]] = B
+    offx = A.shape[1]
+    N = ptsA.shape[0]
+    if conf is not None:
+        order = np.argsort(np.nan_to_num(conf, nan=-1.0))[::-1]
+    else:
+        order = np.arange(N)
+    order = order[: min(N, max_draw)]
+    for i in order:
+        x0, y0 = ptsA[i]
+        x1, y1 = ptsB[i]
+        p0 = (int(round(x0)), int(round(y0)))
+        p1 = (int(round(x1 + offx)), int(round(y1)))
+        cv2.circle(canvas, p0, 2, (0, 255, 0), -1)
+        cv2.circle(canvas, p1, 2, (0, 255, 0), -1)
+        cv2.line(canvas, p0, p1, (0, 200, 255), 1, cv2.LINE_AA)
+    return canvas
+
+
+class TrtRunner:
+    def __init__(self, engine_path):
+        with open(engine_path, "rb") as f:
+            runtime = trt.Runtime(TRT_LOGGER)
+            self.engine = runtime.deserialize_cuda_engine(f.read())
+        self.ctx = self.engine.create_execution_context()
+        self.in0 = "image0"
+        self.in1 = "image1"
+        self.outW = "warp_c"
+        self.outC = "cert_c"
+
+    @torch.inference_mode()
+    def __call__(self, x0: torch.Tensor, x1: torch.Tensor):
+        assert x0.is_cuda and x1.is_cuda
+        B, C, H, W = x0.shape
+        assert (H % 14) == 0 and (W % 14) == 0, "Inputs must be multiples of 14"
+
+        # Set shapes + bind buffers
+        self.ctx.set_input_shape(self.in0, (B, C, H, W))
+        self.ctx.set_input_shape(self.in1, (B, C, H, W))
+        self.ctx.set_tensor_address(self.in0, int(x0.data_ptr()))
+        self.ctx.set_tensor_address(self.in1, int(x1.data_ptr()))
+
+        Ha, Wa = H // 14, W // 14
+        warp_buf = torch.empty((B, Ha, Wa, 2), dtype=torch.float32, device="cuda")
+        cert_buf = torch.empty((B, Ha, Wa), dtype=torch.float32, device="cuda")
+        self.ctx.set_tensor_address(self.outW, int(warp_buf.data_ptr()))
+        self.ctx.set_tensor_address(self.outC, int(cert_buf.data_ptr()))
+
+        self.ctx.execute_async_v3(stream_handle=0)
+        return warp_buf, cert_buf
+
+
+def ransac_filter(pts0, pts1, reproj=3.0, conf=0.999, maxIters=5000):
+    if len(pts0) < 8:
+        return None, np.zeros(len(pts0), dtype=bool)
+    H, mask = cv2.findHomography(
+        pts0,
+        pts1,
+        cv2.RANSAC,
+        ransacReprojThreshold=reproj,
+        confidence=conf,
+        maxIters=maxIters,
+    )
+    inl = (mask.ravel() > 0) if mask is not None else np.zeros(len(pts0), dtype=bool)
+    return H, inl
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--engine", type=str, default="out/matchanything_dense.plan")
+    ap.add_argument("--img0", required=True)
+    ap.add_argument("--img1", required=True)
+    ap.add_argument(
+        "--size", type=int, default=840, help="We will round this up to multiple of 14"
+    )
+    ap.add_argument("--conf_th", type=float, default=0.05)
+    ap.add_argument("--topk", type=int, default=0)
+    ap.add_argument("--no_ransac", action="store_true")
+    ap.add_argument("--out", type=str, default="outputs")
+    args = ap.parse_args()
+
+    x0, img0_bgr = load_rgb_tensor(args.img0, size=args.size)
+    x1, img1_bgr = load_rgb_tensor(args.img1, size=args.size)
+    x0 = x0.cuda()
+    x1 = x1.cuda()
+
+    runner = TrtRunner(args.engine)
+    warp_c, cert_c = runner(x0, x1)  # [1,Ha,Wa,2], [1,Ha,Wa]
+
+    # Build coarse grid for image0
+    _, Ha, Wa, _ = warp_c.shape
+    yy, xx = torch.meshgrid(
+        torch.arange(Ha, device="cuda"), torch.arange(Wa, device="cuda"), indexing="ij"
+    )
+    grid0_c = torch.stack([xx, yy], dim=-1).float()  # [Ha,Wa,2] x,y on coarse grid
+
+    # Flatten matches
+    k0_c = grid0_c.view(-1, 2).cpu().numpy()
+    k1_c = warp_c[0].view(-1, 2).detach().cpu().numpy()
+    mconf = cert_c[0].reshape(-1).detach().cpu().numpy()
+
+    # Host-side filtering (like HF/RoMa)
+    keep = np.isfinite(mconf) & (mconf >= args.conf_th)
+    if args.topk and keep.sum() > args.topk:
+        order = np.argsort(np.nan_to_num(mconf[keep], nan=-1.0))[::-1][: args.topk]
+        idx = np.flatnonzero(keep)[order]
+    else:
+        idx = np.flatnonzero(keep)
+
+    # Scale to pixel coordinates (ViT-L/14 → scale=14)
+    scale = 14.0
+    k0 = k0_c[idx] * scale
+    k1 = k1_c[idx] * scale
+    scores = mconf[idx]
+
+    print(f"Kept {len(scores)} matches @ conf_th={args.conf_th}")
+    if not args.no_ransac and len(scores) >= 8:
+        Hm, inl = ransac_filter(k0, k1)
+        if inl is not None and inl.any():
+            print(f"RANSAC inliers: {inl.sum()}/{len(inl)}")
+            k0, k1, scores = k0[inl], k1[inl], scores[inl]
+    else:
+        k0_r, k1_r, s_r = k0, k1, scores
+    if args.no_ransac or len(scores) < 8:
+        k0_r, k1_r, s_r = k0, k1, scores
+
+    vis = draw_matches_side_by_side(
+        img0_bgr, img1_bgr, k0_r, k1_r, conf=s_r, max_draw=1000
+    )
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem0 = Path(args.img0).stem
+    stem1 = Path(args.img1).stem
+    out_png = out_dir / f"vis_{stem0}_vs_{stem1}.png"
+    ok = cv2.imwrite(str(out_png), vis)
+    print(f"[SAVE] {out_png} (ok={ok})")
+
+
+if __name__ == "__main__":
+    main()

--- a/Convertion_Tensorrt_new/run_trt_dense_dynamic.py
+++ b/Convertion_Tensorrt_new/run_trt_dense_dynamic.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+import numpy as np
+import cv2
+import torch
+import tensorrt as trt
+
+TRT_LOGGER = trt.Logger(trt.Logger.INFO)
+
+
+def load_rgb_tensor(path, size=None):
+    img_bgr = cv2.imread(str(path), cv2.IMREAD_COLOR)
+    if img_bgr is None:
+        raise FileNotFoundError(path)
+    if size:
+        img_bgr = cv2.resize(img_bgr, (size, size), interpolation=cv2.INTER_LANCZOS4)
+    img_rgb = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0
+    t = (
+        torch.from_numpy(np.transpose(img_rgb, (2, 0, 1))[None, ...])
+        .contiguous()
+        .float()
+    )
+    return t, img_bgr
+
+
+def draw_matches_side_by_side(imgA, imgB, ptsA, ptsB, conf=None, max_draw=1000):
+    A = imgA.copy()
+    B = imgB.copy()
+    if A.ndim == 2:
+        A = cv2.cvtColor(A, cv2.COLOR_GRAY2BGR)
+    if B.ndim == 2:
+        B = cv2.cvtColor(B, cv2.COLOR_GRAY2BGR)
+    H = max(A.shape[0], B.shape[0])
+    canvas = np.zeros((H, A.shape[1] + B.shape[1], 3), dtype=np.uint8)
+    canvas[: A.shape[0], : A.shape[1]] = A
+    canvas[: B.shape[0], A.shape[1] : A.shape[1] + B.shape[1]] = B
+    offx = A.shape[1]
+    N = ptsA.shape[0]
+    order = (
+        np.argsort(np.nan_to_num(conf, nan=-1.0))[::-1]
+        if conf is not None
+        else np.arange(N)
+    )
+    order = order[: min(N, max_draw)]
+    for i in order:
+        x0, y0 = ptsA[i]
+        x1, y1 = ptsB[i]
+        p0 = (int(round(x0)), int(round(y0)))
+        p1 = (int(round(x1 + offx)), int(round(y1)))
+        cv2.circle(canvas, p0, 2, (0, 255, 0), -1)
+        cv2.circle(canvas, p1, 2, (0, 255, 0), -1)
+        cv2.line(canvas, p0, p1, (0, 200, 255), 1, cv2.LINE_AA)
+    return canvas
+
+
+class TrtRunner:
+    def __init__(self, engine_path):
+        with open(engine_path, "rb") as f:
+            runtime = trt.Runtime(TRT_LOGGER)
+            self.engine = runtime.deserialize_cuda_engine(f.read())
+        self.ctx = self.engine.create_execution_context()
+        self.in0 = "image0"
+        self.in1 = "image1"
+        self.outW = "warp_c"
+        self.outC = "cert_c"
+        self.outM = "valid_mask"
+        self.outS = "coarse_stride"
+
+    @torch.inference_mode()
+    def __call__(self, x0: torch.Tensor, x1: torch.Tensor):
+        assert x0.is_cuda and x1.is_cuda
+        B, C, H, W = x0.shape
+        self.ctx.set_input_shape(self.in0, (B, C, H, W))
+        self.ctx.set_input_shape(self.in1, (B, C, H, W))
+        self.ctx.set_tensor_address(self.in0, int(x0.data_ptr()))
+        self.ctx.set_tensor_address(self.in1, int(x1.data_ptr()))
+
+        shapeW = self.ctx.get_tensor_shape(self.outW)  # (B,Ha,Wa,2)
+        shapeC = self.ctx.get_tensor_shape(self.outC)  # (B,Ha,Wa)
+        shapeM = self.ctx.get_tensor_shape(self.outM)  # (B,Ha,Wa)
+        shapeS = self.ctx.get_tensor_shape(self.outS)  # (1,)
+
+        warp_buf = torch.empty(tuple(shapeW), dtype=torch.float32, device="cuda")
+        cert_buf = torch.empty(tuple(shapeC), dtype=torch.float32, device="cuda")
+        mask_buf = torch.empty(tuple(shapeM), dtype=torch.float32, device="cuda")
+        stridebuf = torch.empty(tuple(shapeS), dtype=torch.float32, device="cuda")
+        self.ctx.set_tensor_address(self.outW, int(warp_buf.data_ptr()))
+        self.ctx.set_tensor_address(self.outC, int(cert_buf.data_ptr()))
+        self.ctx.set_tensor_address(self.outM, int(mask_buf.data_ptr()))
+        self.ctx.set_tensor_address(self.outS, int(stridebuf.data_ptr()))
+
+        self.ctx.execute_async_v3(stream_handle=0)
+        return warp_buf, cert_buf, mask_buf, stridebuf
+
+
+def ransac_filter(pts0, pts1, reproj=3.0, conf=0.999, maxIters=5000):
+    if len(pts0) < 8:
+        return None, np.zeros(len(pts0), dtype=bool)
+    H, mask = cv2.findHomography(
+        pts0,
+        pts1,
+        cv2.RANSAC,
+        ransacReprojThreshold=reproj,
+        confidence=conf,
+        maxIters=maxIters,
+    )
+    inl = (mask.ravel() > 0) if mask is not None else np.zeros(len(pts0), dtype=bool)
+    return H, inl
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--engine", type=str, default="out/matchanything_dense_dynamic.plan"
+    )
+    ap.add_argument("--img0", required=True)
+    ap.add_argument("--img1", required=True)
+    ap.add_argument(
+        "--size", type=int, default=0, help="Optional square resize. 0=keep originals."
+    )
+    ap.add_argument("--conf_th", type=float, default=0.05)
+    ap.add_argument("--topk", type=int, default=0)
+    ap.add_argument("--no_ransac", action="store_true")
+    ap.add_argument("--out", type=str, default="outputs")
+    args = ap.parse_args()
+
+    x0, im0 = load_rgb_tensor(args.img0, size=(args.size or None))
+    x1, im1 = load_rgb_tensor(args.img1, size=(args.size or None))
+    x0 = x0.cuda()
+    x1 = x1.cuda()
+
+    runner = TrtRunner(args.engine)
+    warp_c, cert_c, valid_c, stride_t = runner(
+        x0, x1
+    )  # [1,Ha,Wa,2], [1,Ha,Wa], [1,Ha,Wa], [1]
+
+    # Build coarse grid for image0
+    _, Ha, Wa, _ = warp_c.shape
+    yy, xx = torch.meshgrid(
+        torch.arange(Ha, device="cuda"), torch.arange(Wa, device="cuda"), indexing="ij"
+    )
+    grid0_c = torch.stack([xx, yy], dim=-1).float()  # [Ha,Wa,2]
+
+    # Flatten + host filtering using mask + conf_th (+topK)
+    k0_c = grid0_c.view(-1, 2).cpu().numpy()
+    k1_c = warp_c[0].view(-1, 2).detach().cpu().numpy()
+    mconf = cert_c[0].reshape(-1).detach().cpu().numpy()
+    mval = valid_c[0].reshape(-1).detach().cpu().numpy()
+
+    keep = (mval > 0.5) & np.isfinite(mconf) & (mconf >= args.conf_th)
+    idx = np.flatnonzero(keep)
+    if args.topk and idx.size > args.topk:
+        order = np.argsort(np.nan_to_num(mconf[idx], nan=-1.0))[::-1][: args.topk]
+        idx = idx[order]
+
+    stride = float(stride_t[0].item())
+    k0 = k0_c[idx] * stride
+    k1 = k1_c[idx] * stride
+    scores = mconf[idx]
+
+    print(f"Kept {len(scores)} matches @ conf_th={args.conf_th}")
+    if not args.no_ransac and len(scores) >= 8:
+        Hm, inl = ransac_filter(k0, k1)
+        if inl is not None and inl.any():
+            print(f"RANSAC inliers: {inl.sum()}/{len(inl)}")
+            k0, k1, scores = k0[inl], k1[inl], scores[inl]
+
+    vis = draw_matches_side_by_side(im0, im1, k0, k1, conf=scores, max_draw=1000)
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem0 = Path(args.img0).stem
+    stem1 = Path(args.img1).stem
+    out_png = out_dir / f"vis_{stem0}_vs_{stem1}.png"
+    ok = cv2.imwrite(str(out_png), vis)
+    print(f"[SAVE] {out_png} (ok={ok})")
+
+
+if __name__ == "__main__":
+    main()

--- a/Convertion_Tensorrt_new/verify_onnx_dense.py
+++ b/Convertion_Tensorrt_new/verify_onnx_dense.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import cv2
+import numpy as np
+import onnxruntime as ort
+
+
+def ceil_mul14(x):
+    return ((x + 13) // 14) * 14
+
+
+def load_rgb(path, size=None):
+    img = cv2.imread(path, cv2.IMREAD_COLOR)
+    if size is not None:
+        s = ceil_mul14(size)
+        img = cv2.resize(img, (s, s), interpolation=cv2.INTER_LANCZOS4)
+    rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0
+    x = np.transpose(rgb[None, ...], (0, 3, 1, 2)).astype(np.float32)
+    return x, img
+
+
+sess = ort.InferenceSession(
+    "out/matchanything_dense.onnx", providers=["CPUExecutionProvider"]
+)
+in0, in1 = sess.get_inputs()[0].name, sess.get_inputs()[1].name
+outW, outC = sess.get_outputs()[0].name, sess.get_outputs()[1].name
+
+x0, im0 = load_rgb("IMG_A.jpg", size=840)
+x1, im1 = load_rgb("IMG_B.jpg", size=840)
+warp_c, cert_c = sess.run([outW, outC], {in0: x0, in1: x1})
+print("warp_c:", warp_c.shape, "cert_c:", cert_c.shape)


### PR DESCRIPTION
## Summary
- add dynamic ONNX export with unified weight loading
- include dense ONNX export helpers and TensorRT runners

## Testing
- `pre-commit run --files Convertion_Tensorrt_new/accurate_matchanything_trt_dyn.py Convertion_Tensorrt_new/export_dense_onnx.py Convertion_Tensorrt_new/export_dynamic_onnx_unified.py Convertion_Tensorrt_new/run_trt_dense_dynamic.py Convertion_Tensorrt_new/verify_onnx_dense.py Convertion_Tensorrt_new/run_trt_dense.py`
- `pre-commit run --files Convertion_Tensorrt_new/verify_onnx_dense.py`

------
https://chatgpt.com/codex/tasks/task_e_68c2a7d349448322a74722dee8940701