### PR TITLE
Add dynamic TensorRT export and hybrid weight utilities

### DIFF
--- a/Convertion_Tensorrt/better_weight_adapter.py
+++ b/Convertion_Tensorrt/better_weight_adapter.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Better weight adapter that handles the specific MatchAnything checkpoint structure.
+"""
+
+import re
+import torch
+
+
+def create_better_mapping_rules():
+    """Enhanced mapping rules for MatchAnything checkpoint."""
+    return [
+        # Remove wrappers
+        (re.compile(r"^module\."), ""),
+        (re.compile(r"^_orig_mod\."), ""),
+        # MatchAnything structure - the key insight is that we need to map the adapted DINOv2 weights
+        (re.compile(r"^encoder\.dino\."), "encoder.dino."),  # Keep DINOv2 weights as-is
+        # CNN encoder mapping
+        (re.compile(r"^matcher\.model\.encoder\.cnn\.layers\."), "encoder.layers."),
+        (re.compile(r"^matcher\.model\.encoder\."), "encoder."),
+        # Matcher/decoder mapping
+        (re.compile(r"^matcher\.model\.decoder\."), "matcher."),
+        (re.compile(r"^matcher\.model\."), ""),
+        (re.compile(r"^matcher\."), ""),
+        (re.compile(r"^model\."), ""),
+    ]
+
+
+def better_remap_and_load(model, ckpt_path: str):
+    """Better weight loading with enhanced diagnostics."""
+    print(f"[BETTER] Loading checkpoint: {ckpt_path}")
+
+    raw = torch.load(ckpt_path, map_location="cpu")
+    ckpt_state_dict = raw.get("state_dict", raw)
+    model_state_dict = model.state_dict()
+
+    print(f"[BETTER] Checkpoint: {len(ckpt_state_dict)} keys")
+    print(f"[BETTER] Model: {len(model_state_dict)} keys")
+
+    # Analyze checkpoint prefixes
+    ckpt_prefixes = {}
+    for key in ckpt_state_dict.keys():
+        prefix = ".".join(key.split(".")[:2])
+        ckpt_prefixes[prefix] = ckpt_prefixes.get(prefix, 0) + 1
+
+    print("[BETTER] Checkpoint key prefixes:")
+    for prefix, count in sorted(
+        ckpt_prefixes.items(), key=lambda x: x[1], reverse=True
+    )[:15]:
+        print(f"  {prefix}: {count}")
+
+    # Apply mapping
+    rules = create_better_mapping_rules()
+    mapped = {}
+
+    for ckpt_key, ckpt_value in ckpt_state_dict.items():
+        mapped_key = ckpt_key
+        for pattern, replacement in rules:
+            mapped_key = pattern.sub(replacement, mapped_key)
+        mapped[mapped_key] = ckpt_value
+
+    # Direct matches
+    loadable = {}
+    shape_mismatches = []
+
+    for model_key, model_tensor in model_state_dict.items():
+        if model_key in mapped:
+            ckpt_tensor = mapped[model_key]
+            if ckpt_tensor.shape == model_tensor.shape:
+                loadable[model_key] = ckpt_tensor
+            else:
+                shape_mismatches.append(
+                    (model_key, ckpt_tensor.shape, model_tensor.shape)
+                )
+
+    print(f"[BETTER] Direct matches: {len(loadable)}")
+
+    # Show what DINOv2 weights we have
+    dino_available = [k for k in mapped.keys() if k.startswith("encoder.dino.")]
+    dino_needed = [k for k in model_state_dict.keys() if k.startswith("encoder.dino.")]
+    dino_matched = [k for k in loadable.keys() if k.startswith("encoder.dino.")]
+
+    print(
+        f"[BETTER] DINOv2 weights - Available: {len(dino_available)}, Needed: {len(dino_needed)}, Matched: {len(dino_matched)}"
+    )
+
+    if len(dino_matched) < len(dino_needed):
+        print("[BETTER] Missing DINOv2 weights (first 10):")
+        missing_dino = [k for k in dino_needed if k not in dino_matched]
+        for key in missing_dino[:10]:
+            print(f"  - {key}")
+
+        print("[BETTER] Available DINOv2 weights (first 10):")
+        for key in dino_available[:10]:
+            print(f"  + {key}")
+
+    # Load the weights
+    missing, unexpected = model.load_state_dict(loadable, strict=False)
+
+    print("[BETTER] Final result:")
+    print(f"  Loaded: {len(loadable)}")
+    print(f"  Missing: {len(missing)}")
+    print(f"  Unexpected: {len(unexpected)}")
+    print(f"  Shape mismatches: {len(shape_mismatches)}")
+
+    if shape_mismatches:
+        print("[BETTER] Shape mismatches (first 5):")
+        for key, ckpt_shape, model_shape in shape_mismatches[:5]:
+            print(f"  {key}: {ckpt_shape} vs {model_shape}")
+
+    return loadable
+
+
+if __name__ == "__main__":
+    # Test the better adapter
+    import sys
+
+    sys.path.append(".")
+    from accurate_matchanything_trt import AccurateMatchAnythingTRT
+
+    model = AccurateMatchAnythingTRT(model_name="matchanything_roma")
+    better_remap_and_load(
+        model,
+        "../imcui/third_party/MatchAnything/weights/matchanything_roma_adapted_dino.ckpt",
+    )

--- a/Convertion_Tensorrt/create_hybrid_checkpoint.py
+++ b/Convertion_Tensorrt/create_hybrid_checkpoint.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Create a hybrid checkpoint that combines:
+1. DINOv2 essential components (patch_embed, pos_embed, cls_token)
+2. Transformer blocks from your checkpoint
+"""
+
+import torch
+import timm
+
+
+def create_hybrid_checkpoint():
+    """Create hybrid checkpoint with DINOv2 essentials + your transformer blocks."""
+
+    print("Creating hybrid MatchAnything checkpoint...")
+
+    # 1. Load your checkpoint (has transformer blocks)
+    print("[1/4] Loading your checkpoint...")
+    your_ckpt = torch.load(
+        "../imcui/third_party/MatchAnything/weights/matchanything_roma.ckpt",
+        map_location="cpu",
+    )
+    your_weights = your_ckpt.get("state_dict", your_ckpt)
+
+    print(f"Your checkpoint: {len(your_weights)} keys")
+
+    # 2. Load DINOv2 for essential components
+    print("[2/4] Loading DINOv2 for essential components...")
+    dinov2_model = timm.create_model("vit_large_patch14_dinov2", pretrained=True)
+    dinov2_weights = dinov2_model.state_dict()
+
+    print(f"DINOv2 weights: {len(dinov2_weights)} keys")
+
+    # 3. Create hybrid weights
+    print("[3/4] Creating hybrid weights...")
+    hybrid_weights = {}
+
+    # Add your original MatchAnything weights (CNN encoder, matcher, etc.)
+    for key, value in your_weights.items():
+        hybrid_weights[key] = value
+
+    # Add essential DINOv2 components with adaptation
+    essential_components = [
+        "cls_token",
+        "pos_embed",
+        "patch_embed.proj.weight",
+        "patch_embed.proj.bias",
+        "mask_token",
+    ]
+
+    for component in essential_components:
+        if component in dinov2_weights:
+            value = dinov2_weights[component]
+
+            if component == "pos_embed":
+                # Adapt position embedding from DINOv2's size to ViT/16 size
+                # DINOv2: [1, 1370, 1024] -> Target: [1, 197, 1024]
+                print(f"  Adapting {component} from {value.shape}")
+                cls_token = value[:, :1, :]  # [1, 1, 1024]
+                spatial_tokens = value[:, 1:, :]  # [1, 1369, 1024]
+
+                # Reshape and interpolate spatial tokens
+                H = W = int(spatial_tokens.shape[1] ** 0.5)  # 37x37
+                spatial_2d = spatial_tokens.reshape(1, H, W, 1024).permute(0, 3, 1, 2)
+
+                # Interpolate to 14x14 (for 224x224 images with 16x16 patches)
+                spatial_resized = (
+                    torch.nn.functional.interpolate(
+                        spatial_2d, size=(14, 14), mode="bilinear", align_corners=False
+                    )
+                    .permute(0, 2, 3, 1)
+                    .reshape(1, 196, 1024)
+                )
+
+                adapted_pos_embed = torch.cat([cls_token, spatial_resized], dim=1)
+                hybrid_weights[f"encoder.dino.{component}"] = adapted_pos_embed
+                print(f"  Adapted to: {adapted_pos_embed.shape}")
+
+            elif component == "patch_embed.proj.weight":
+                # Adapt patch embedding from 14x14 to 16x16
+                print(f"  Adapting {component} from {value.shape}")
+                adapted_patch = torch.nn.functional.interpolate(
+                    value, size=(16, 16), mode="bilinear", align_corners=False
+                )
+                hybrid_weights[f"encoder.dino.{component}"] = adapted_patch
+                print(f"  Adapted to: {adapted_patch.shape}")
+
+            else:
+                hybrid_weights[f"encoder.dino.{component}"] = value
+                print(f"  Added {component}: {value.shape}")
+
+    # Add transformer blocks from your checkpoint with structure fix
+    print("  Processing transformer blocks from your checkpoint...")
+    embedding_decoder_keys = [
+        k for k in your_weights.keys() if "embedding_decoder.blocks." in k
+    ]
+
+    for key in embedding_decoder_keys:
+        # Map: matcher.model.decoder.embedding_decoder.blocks.X.* -> encoder.dino.blocks.X.0.*
+        new_key = key.replace(
+            "matcher.model.decoder.embedding_decoder.", "encoder.dino."
+        )
+
+        # Fix block structure: blocks.X.* -> blocks.X.0.*
+        if ".blocks." in new_key:
+            parts = new_key.split(".")
+            # Find the block number and insert '0' after it
+            for i, part in enumerate(parts):
+                if part == "blocks" and i + 1 < len(parts) and parts[i + 1].isdigit():
+                    parts.insert(i + 2, "0")  # Insert '0' after the block number
+                    break
+            new_key = ".".join(parts)
+
+        hybrid_weights[new_key] = your_weights[key]
+
+    print(f"  Added {len(embedding_decoder_keys)} transformer blocks")
+
+    # 4. Save hybrid checkpoint
+    print("[4/4] Saving hybrid checkpoint...")
+    output_path = (
+        "../imcui/third_party/MatchAnything/weights/matchanything_roma_hybrid.ckpt"
+    )
+    torch.save({"state_dict": hybrid_weights}, output_path)
+
+    print(f"✅ Hybrid checkpoint created: {output_path}")
+    print(f"Total keys: {len(hybrid_weights)}")
+
+    # Analyze what we have
+    dino_keys = [k for k in hybrid_weights.keys() if k.startswith("encoder.dino.")]
+    print(f"DINOv2 keys: {len(dino_keys)}")
+
+    essential_found = [
+        k
+        for k in dino_keys
+        if any(comp in k for comp in ["cls_token", "pos_embed", "patch_embed"])
+    ]
+    blocks_found = [k for k in dino_keys if "blocks." in k]
+
+    print(f"Essential components: {len(essential_found)}")
+    print(f"Transformer blocks: {len(blocks_found)}")
+
+    return output_path
+
+
+def test_hybrid_checkpoint(hybrid_path):
+    """Test the hybrid checkpoint with the model."""
+    print(f"\nTesting hybrid checkpoint: {hybrid_path}")
+
+    import sys
+
+    sys.path.append(".")
+    from accurate_matchanything_trt import AccurateMatchAnythingTRT
+
+    model = AccurateMatchAnythingTRT(model_name="matchanything_roma")
+
+    # Load hybrid checkpoint
+    hybrid_ckpt = torch.load(hybrid_path, map_location="cpu")
+    hybrid_weights = hybrid_ckpt.get("state_dict", hybrid_ckpt)
+
+    # Try loading
+    missing, unexpected = model.load_state_dict(hybrid_weights, strict=False)
+
+    model_total = len(model.state_dict())
+    loaded_count = model_total - len(missing)
+
+    print("Loading results:")
+    print(f"  Loaded: {loaded_count}/{model_total}")
+    print(f"  Missing: {len(missing)}")
+    print(f"  Unexpected: {len(unexpected)}")
+
+    # Check DINOv2 specifically
+    dino_model_keys = [
+        k for k in model.state_dict().keys() if k.startswith("encoder.dino.")
+    ]
+    dino_loaded = [k for k in dino_model_keys if k not in missing]
+
+    print(f"  DINOv2 loaded: {len(dino_loaded)}/{len(dino_model_keys)}")
+
+    if len(missing) > 0:
+        print(f"Missing keys (first 10): {missing[:10]}")
+
+    return loaded_count, model_total
+
+
+if __name__ == "__main__":
+    hybrid_path = create_hybrid_checkpoint()
+    test_hybrid_checkpoint(hybrid_path)

--- a/Convertion_Tensorrt/export_complete_matchanything.py
+++ b/Convertion_Tensorrt/export_complete_matchanything.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Complete MatchAnything ONNX export with unified weight loading."""
+
+from pathlib import Path
+import os
+from typing import Optional
+
+import onnx
+import torch
+
+from accurate_matchanything_trt import AccurateMatchAnythingTRT
+from unified_weight_loader import apply_unified_weight_loading
+
+
+def export_complete_matchanything_onnx(
+    onnx_path: str,
+    checkpoint_path: Optional[str],
+    H: int = 832,
+    W: int = 832,
+    match_threshold: float = 0.1,
+    use_external_data: bool = True,
+) -> str:
+    """Export the full MatchAnything model with weights to ONNX."""
+    device = "cpu"
+    model = (
+        AccurateMatchAnythingTRT(
+            model_name="matchanything_roma",
+            match_threshold=match_threshold,
+            amp=False,
+        )
+        .to(device)
+        .eval()
+    )
+
+    if checkpoint_path and os.path.exists(checkpoint_path):
+        model_state = model.state_dict()
+        loadable = apply_unified_weight_loading(
+            checkpoint_path, model_state, load_dinov2_components=True
+        )
+        missing, unexpected = model.load_state_dict(loadable, strict=False)
+        print(
+            f"[EXPORT] Model loading: {len(loadable)} loaded, "
+            f"{len(missing)} missing, {len(unexpected)} unexpected"
+        )
+    else:
+        print("[EXPORT] No checkpoint provided - using random initialization")
+
+    # Dummy forward for shape discovery
+    x0 = torch.rand(1, 3, H, W, device=device)
+    x1 = torch.rand(1, 3, H, W, device=device)
+    with torch.no_grad():
+        out = model(x0, x1)
+        print(
+            f"[EXPORT] Forward pass OK: {out['keypoints0'].shape} "
+            f"{out['keypoints1'].shape}"
+        )
+
+    dynamic_axes = {
+        "image0": {0: "B", 2: "H", 3: "W"},
+        "image1": {0: "B", 2: "H", 3: "W"},
+        "keypoints0": {0: "num_matches"},
+        "keypoints1": {0: "num_matches"},
+        "mconf": {0: "num_matches"},
+    }
+
+    export_kwargs = dict(
+        input_names=["image0", "image1"],
+        output_names=["keypoints0", "keypoints1", "mconf"],
+        dynamic_axes=dynamic_axes,
+        opset_version=17,
+        do_constant_folding=True,
+        verbose=False,
+    )
+
+    onnx_path = Path(onnx_path)
+    onnx_path.parent.mkdir(parents=True, exist_ok=True)
+    torch.onnx.export(model, (x0, x1), str(onnx_path), **export_kwargs)
+    print(f"[EXPORT] Saved -> {onnx_path}")
+
+    if use_external_data:
+        try:
+            mp = onnx.load(str(onnx_path), load_external_data=False)
+            data_file = onnx_path.with_suffix(onnx_path.suffix + ".data")
+            onnx.external_data_utils.convert_model_to_external_data(
+                mp,
+                all_tensors_to_one_file=True,
+                location=data_file.name,
+                size_threshold=0,
+            )
+            onnx.save_model(mp, str(onnx_path), save_as_external_data=True)
+            print(f"[EXPORT] External data -> {onnx_path} (+{data_file.name})")
+        except Exception as e:
+            print(f"[EXPORT] External data conversion failed: {e}")
+
+    return str(onnx_path)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Export complete MatchAnything ONNX")
+    ap.add_argument("--onnx", default="out/matchanything_complete_export.onnx")
+    ap.add_argument("--checkpoint", default="", help="Checkpoint path")
+    ap.add_argument("--size", type=int, default=832)
+    ap.add_argument("--match_threshold", type=float, default=0.1)
+    ap.add_argument("--no_external_data", action="store_true")
+    args = ap.parse_args()
+
+    export_complete_matchanything_onnx(
+        args.onnx,
+        args.checkpoint or None,
+        H=args.size,
+        W=args.size,
+        match_threshold=args.match_threshold,
+        use_external_data=not args.no_external_data,
+    )

--- a/Convertion_Tensorrt/fix_onnx_export.py
+++ b/Convertion_Tensorrt/fix_onnx_export.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Fixed ONNX export that properly saves weights to external data file.
+"""
+
+import torch
+import onnx
+import os
+from pathlib import Path
+
+try:
+    from onnx import external_data_utils
+except ImportError:
+    from onnx import external_data_helper as external_data_utils
+
+
+def export_with_proper_weights(model, dummy_inputs, onnx_path):
+    """Export ONNX with proper weight handling"""
+
+    # Ensure output directory exists
+    os.makedirs(os.path.dirname(onnx_path) or ".", exist_ok=True)
+
+    print(f"[FIXED] Exporting to {onnx_path}")
+
+    # First, export normally (this will create multiple weight files)
+    torch.onnx.export(
+        model,
+        dummy_inputs,
+        onnx_path,
+        input_names=["image0", "image1"],
+        output_names=["keypoints0", "keypoints1", "mconf"],
+        dynamic_axes={
+            "image0": {0: "B", 2: "H", 3: "W"},
+            "image1": {0: "B", 2: "H", 3: "W"},
+            "keypoints0": {0: "num_matches"},
+            "keypoints1": {0: "num_matches"},
+            "mconf": {0: "num_matches"},
+        },
+        opset_version=17,
+        do_constant_folding=True,
+        verbose=False,
+    )
+
+    print("[FIXED] Initial export complete")
+
+    # Load and re-save with proper external data handling
+    print("[FIXED] Consolidating external data...")
+
+    try:
+        # Load the model with all external data
+        model_proto = onnx.load(onnx_path, load_external_data=True)
+
+        # Convert to single external data file
+        data_filename = os.path.basename(onnx_path) + ".data"
+        external_data_utils.convert_model_to_external_data(
+            model_proto,
+            all_tensors_to_one_file=True,
+            location=data_filename,
+            size_threshold=1024,  # 1KB threshold
+        )
+
+        # Save the consolidated model
+        onnx.save_model(
+            model_proto,
+            onnx_path,
+            save_as_external_data=True,
+        )
+
+        print("[FIXED] Model consolidated successfully")
+
+    except Exception as e:
+        print(f"[FIXED] Error during consolidation: {e}")
+        print("[FIXED] Trying alternative approach...")
+
+        # Alternative: Load without external data, then convert
+        try:
+            model_proto = onnx.load(onnx_path, load_external_data=False)
+
+            # Find all external data files
+            out_dir = Path(onnx_path).parent
+            external_files = list(out_dir.glob("onnx__*"))
+            print(f"[FIXED] Found {len(external_files)} external data files")
+
+            if external_files:
+                # Load with external data
+                model_proto = onnx.load(onnx_path, load_external_data=True)
+
+                # Convert to single file
+                data_filename = os.path.basename(onnx_path) + ".data"
+                external_data_utils.convert_model_to_external_data(
+                    model_proto,
+                    all_tensors_to_one_file=True,
+                    location=data_filename,
+                    size_threshold=0,  # Include all tensors
+                )
+
+                # Save
+                onnx.save_model(
+                    model_proto,
+                    onnx_path,
+                    save_as_external_data=True,
+                )
+                print("[FIXED] Alternative consolidation successful")
+            else:
+                print("[FIXED] No external data files found - weights may be embedded")
+
+        except Exception as e2:
+            print(f"[FIXED] Alternative approach also failed: {e2}")
+
+    # Clean up temporary files
+    out_dir = Path(onnx_path).parent
+    temp_files = list(out_dir.glob("onnx__*"))
+    if temp_files:
+        print(f"[FIXED] Cleaning up {len(temp_files)} temporary files...")
+        for temp_file in temp_files:
+            try:
+                temp_file.unlink(missing_ok=True)
+            except Exception:
+                pass
+
+    # Check final file sizes
+    onnx_size = os.path.getsize(onnx_path) / (1024 * 1024)
+    data_file = onnx_path + ".data"
+
+    print("[FIXED] Export complete!")
+    print(f"  - ONNX file: {onnx_size:.1f} MB")
+
+    if os.path.exists(data_file):
+        data_size = os.path.getsize(data_file) / (1024 * 1024)
+        print(f"  - Data file: {data_size:.1f} MB")
+
+        if data_size > 100:
+            print("  ✅ Success! Data file size indicates weights are properly saved")
+            return True
+        else:
+            print("  ❌ Warning: Data file still too small")
+            return False
+    else:
+        print("  ❌ No data file created - weights may be embedded in ONNX")
+        if onnx_size > 100:
+            print("  ✅ But ONNX file is large, so weights might be embedded")
+            return True
+        else:
+            print("  ❌ ONNX file is also small - weights are missing")
+            return False
+
+
+if __name__ == "__main__":
+    print("Fixed ONNX export utility")

--- a/Convertion_Tensorrt/fix_onnx_external.py
+++ b/Convertion_Tensorrt/fix_onnx_external.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+import onnx
+import os
+
+try:
+    from onnx import external_data_utils
+except ImportError:
+    from onnx import external_data_helper as external_data_utils
+
+
+def fix_onnx_external_data(input_onnx, output_onnx):
+    """Convert embedded ONNX to external data format for TensorRT"""
+
+    print(f"[FIX] Loading {input_onnx}")
+    print(f"[FIX] Input size: {os.path.getsize(input_onnx) / (1024*1024):.1f} MB")
+
+    # Load the ONNX model
+    model = onnx.load(input_onnx, load_external_data=False)
+
+    # Count embedded parameters
+    embedded_params = 0
+    for init in model.graph.initializer:
+        if init.raw_data or init.float_data or init.int64_data:
+            param_count = 1
+            for dim in init.dims:
+                param_count *= dim
+            embedded_params += param_count
+
+    print(f"[FIX] Found {embedded_params:,} embedded parameters")
+
+    # Convert to external data format
+    print("[FIX] Converting to external data format...")
+
+    # Ensure output directory exists
+    os.makedirs(os.path.dirname(output_onnx) or ".", exist_ok=True)
+
+    # Convert all weights to external data
+    external_data_utils.convert_model_to_external_data(
+        model,
+        all_tensors_to_one_file=True,
+        location=os.path.basename(output_onnx) + ".data",
+        size_threshold=1024,  # Externalize anything > 1KB
+    )
+
+    # Save the model
+    onnx.save_model(model, output_onnx, save_as_external_data=True)
+
+    # Check results
+    onnx_size = os.path.getsize(output_onnx) / (1024 * 1024)
+    data_file = output_onnx + ".data"
+
+    print(f"[FIX] Output ONNX size: {onnx_size:.1f} MB")
+
+    if os.path.exists(data_file):
+        data_size = os.path.getsize(data_file) / (1024 * 1024)
+        print(f"[FIX] Output data size: {data_size:.1f} MB")
+        print(f"[FIX] Total size: {onnx_size + data_size:.1f} MB")
+
+        if data_size > 100:
+            print("✅ SUCCESS! External data file created properly")
+            return True
+        else:
+            print("❌ External data file too small")
+            return False
+    else:
+        print("❌ No external data file created")
+        return False
+
+
+if __name__ == "__main__":
+    success = fix_onnx_external_data(
+        "out/matchanything_complete.onnx", "out/matchanything_external.onnx"
+    )
+    print(f"Conversion {'succeeded' if success else 'failed'}")

--- a/Convertion_Tensorrt/fixed_weight_adapter.py
+++ b/Convertion_Tensorrt/fixed_weight_adapter.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Fixed weight adapter that correctly maps DINOv2 block structure.
+"""
+
+import re
+import torch
+from typing import Dict
+
+
+def fix_dino_block_structure(
+    ckpt_state_dict: Dict[str, torch.Tensor],
+) -> Dict[str, torch.Tensor]:
+    """Fix the DINOv2 block structure to match model expectations."""
+
+    fixed_dict = {}
+
+    for key, value in ckpt_state_dict.items():
+        new_key = key
+
+        # Fix DINOv2 block structure: blocks.X. -> blocks.X.0.
+        if (
+            key.startswith("encoder.dino.blocks.")
+            and ".norm" in key
+            or ".attn" in key
+            or ".mlp" in key
+        ):
+            # Parse the key: encoder.dino.blocks.0.norm1.weight -> encoder.dino.blocks.0.0.norm1.weight
+            parts = key.split(".")
+            if len(parts) >= 5 and parts[3].isdigit():  # blocks.0.norm1...
+                # Insert an extra '0' after the block number
+                parts.insert(4, "0")
+                new_key = ".".join(parts)
+                print(f"Fixed block structure: {key} -> {new_key}")
+
+        fixed_dict[new_key] = value
+
+    return fixed_dict
+
+
+def apply_fixed_mapping(model, ckpt_path: str):
+    """Apply the fixed mapping with correct block structure."""
+
+    print(f"[FIXED] Loading checkpoint: {ckpt_path}")
+    raw = torch.load(ckpt_path, map_location="cpu")
+    ckpt_state_dict = raw.get("state_dict", raw)
+
+    print(f"[FIXED] Original checkpoint: {len(ckpt_state_dict)} keys")
+
+    # Fix the DINOv2 block structure
+    fixed_dict = fix_dino_block_structure(ckpt_state_dict)
+
+    print(f"[FIXED] After block structure fix: {len(fixed_dict)} keys")
+
+    # Apply standard mapping rules
+    rules = [
+        (re.compile(r"^module\."), ""),
+        (re.compile(r"^matcher\.model\.encoder\.cnn\.layers\."), "encoder.layers."),
+        (re.compile(r"^matcher\.model\.encoder\."), "encoder."),
+        (re.compile(r"^matcher\.model\.decoder\."), "matcher."),
+        (re.compile(r"^matcher\.model\."), ""),
+        (re.compile(r"^matcher\."), ""),
+    ]
+
+    mapped_dict = {}
+    for key, value in fixed_dict.items():
+        mapped_key = key
+        for pattern, replacement in rules:
+            mapped_key = pattern.sub(replacement, mapped_key)
+        mapped_dict[mapped_key] = value
+
+    # Load into model
+    model_state_dict = model.state_dict()
+    loadable = {}
+
+    for model_key, model_tensor in model_state_dict.items():
+        if model_key in mapped_dict:
+            ckpt_tensor = mapped_dict[model_key]
+            if ckpt_tensor.shape == model_tensor.shape:
+                loadable[model_key] = ckpt_tensor
+
+    # Load the weights
+    missing, unexpected = model.load_state_dict(loadable, strict=False)
+
+    # Count DINOv2 weights specifically
+    dino_loaded = len([k for k in loadable.keys() if k.startswith("encoder.dino.")])
+    dino_total = len(
+        [k for k in model_state_dict.keys() if k.startswith("encoder.dino.")]
+    )
+
+    print("[FIXED] Results:")
+    print(f"  Total loaded: {len(loadable)}/{len(model_state_dict)}")
+    print(f"  DINOv2 loaded: {dino_loaded}/{dino_total}")
+    print(f"  Missing: {len(missing)}")
+
+    return loadable
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.path.append(".")
+    from accurate_matchanything_trt import AccurateMatchAnythingTRT
+
+    model = AccurateMatchAnythingTRT(model_name="matchanything_roma")
+    apply_fixed_mapping(
+        model,
+        "../imcui/third_party/MatchAnything/weights/matchanything_roma_adapted_dino.ckpt",
+    )

--- a/Convertion_Tensorrt/run_trt_matchanything_trt10.py
+++ b/Convertion_Tensorrt/run_trt_matchanything_trt10.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import argparse
+from pathlib import Path
+
+import cv2
+import numpy as np
+import tensorrt as trt
+import torch
+
+TRT_LOGGER = trt.Logger(trt.Logger.INFO)
+
+
+# ------------------------- image utils -------------------------
+def load_rgb_tensor(path, size=(832, 832), norm="none"):
+    """
+    Read BGR image, resize to `size`, convert to RGB, return:
+      - x:  NCHW float32 torch tensor on CPU (normalized per `norm`)
+      - img_bgr_orig: original BGR (for viz)
+      - img_bgr_resz: resized BGR (for viz in network space)
+    norm in {"none","imagenet","neg_one_one"}
+    """
+    img_bgr = cv2.imread(str(path), cv2.IMREAD_COLOR)
+    if img_bgr is None:
+        raise FileNotFoundError(path)
+    if size is not None:
+        img_bgr_resz = cv2.resize(img_bgr, size, interpolation=cv2.INTER_LANCZOS4)
+    else:
+        img_bgr_resz = img_bgr
+
+    img_rgb = cv2.cvtColor(img_bgr_resz, cv2.COLOR_BGR2RGB).astype(np.float32)
+
+    # scale/normalize
+    if norm == "imagenet":
+        # [0,1], then (x-mean)/std per channel
+        x = img_rgb / 255.0
+        mean = np.array([0.485, 0.456, 0.406], dtype=np.float32)[None, None, :]
+        std = np.array([0.229, 0.224, 0.225], dtype=np.float32)[None, None, :]
+        x = (x - mean) / std
+    elif norm == "neg_one_one":
+        # [-1, 1]
+        x = (img_rgb / 127.5) - 1.0
+    else:
+        # [0,1]
+        x = img_rgb / 255.0
+
+    # HWC -> NCHW
+    x = torch.from_numpy(x).permute(2, 0, 1).unsqueeze(0).contiguous().float()
+    return x, img_bgr, img_bgr_resz
+
+
+def to_numpy(t):  # detach-safe
+    return t.detach().cpu().numpy()
+
+
+# ------------------------- TensorRT runner (TRT-10) -------------------------
+class TrtRunner:
+    def __init__(self, engine_path):
+        with open(engine_path, "rb") as f:
+            runtime = trt.Runtime(TRT_LOGGER)
+            self.engine = runtime.deserialize_cuda_engine(f.read())
+        if self.engine is None:
+            raise RuntimeError(f"Failed to load engine: {engine_path}")
+        self.ctx = self.engine.create_execution_context()
+
+        # Name-based I/O (per your engine)
+        self.in0 = "image0"
+        self.in1 = "image1"
+        self.out_k0 = "keypoints0"
+        self.out_k1 = "keypoints1"
+        self.out_mc = "mconf"
+
+    @torch.inference_mode()
+    def __call__(self, x0: torch.Tensor, x1: torch.Tensor):
+        assert x0.is_cuda and x1.is_cuda, "Inputs must be on CUDA (use .cuda())"
+        B, C, H, W = x0.shape
+
+        # Bind dynamic shapes
+        self.ctx.set_input_shape(self.in0, (B, C, H, W))
+        self.ctx.set_input_shape(self.in1, (B, C, H, W))
+
+        # Zero-copy inputs
+        self.ctx.set_tensor_address(self.in0, int(x0.data_ptr()))
+        self.ctx.set_tensor_address(self.in1, int(x1.data_ptr()))
+
+        # Allocate worst-case outputs (grid ~ (H/16)*(W/16))
+        grid = (H // 16) * (W // 16)
+        k0_buf = torch.empty((grid, 2), dtype=torch.float32, device="cuda")
+        k1_buf = torch.empty((grid, 2), dtype=torch.float32, device="cuda")
+        mc_buf = torch.empty((grid, 1), dtype=torch.float32, device="cuda")
+
+        self.ctx.set_tensor_address(self.out_k0, int(k0_buf.data_ptr()))
+        self.ctx.set_tensor_address(self.out_k1, int(k1_buf.data_ptr()))
+        self.ctx.set_tensor_address(self.out_mc, int(mc_buf.data_ptr()))
+
+        # Execute (default stream 0)
+        self.ctx.execute_async_v3(stream_handle=0)
+
+        # Query actual produced N
+        n = self.ctx.get_tensor_shape(self.out_k0)[0]
+        if n == 0:
+            return (
+                np.empty((0, 2), np.float32),
+                np.empty((0, 2), np.float32),
+                np.empty((0,), np.float32),
+            )
+        k0 = to_numpy(k0_buf[:n])
+        k1 = to_numpy(k1_buf[:n])
+        mc = to_numpy(mc_buf[:n, 0])
+        return k0, k1, mc
+
+
+# ------------------------- geometry / filters -------------------------
+def ransac_filter(pts0, pts1, reproj=3.0, conf=0.999, maxIters=5000):
+    if len(pts0) < 8:
+        return None, np.zeros(len(pts0), dtype=bool)
+    H, mask = cv2.findHomography(
+        pts0,
+        pts1,
+        cv2.RANSAC,
+        ransacReprojThreshold=reproj,
+        confidence=conf,
+        maxIters=maxIters,
+    )
+    inl = (mask.ravel() > 0) if mask is not None else np.zeros(len(pts0), dtype=bool)
+    return H, inl
+
+
+def pairwise_sqdist(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """
+    Return an (N, M) matrix of squared Euclidean distances between
+    a (N,2) and b (M,2), using broadcasting.
+    """
+    a = np.asarray(a, dtype=np.float32)
+    b = np.asarray(b, dtype=np.float32)
+    # (N,1,2) - (1,M,2) -> (N,M,2)  then sum over last axis -> (N,M)
+    diff = a[:, None, :] - b[None, :, :]
+    return np.sum(diff * diff, axis=2)
+
+
+def mutual_nn(pts0: np.ndarray, pts1: np.ndarray, eps: float = 3.0) -> np.ndarray:
+    """
+    Mutual nearest neighbors within eps (in *resized* pixel units).
+    Returns a boolean mask of length N (for pts0).
+    """
+    if len(pts0) == 0 or len(pts1) == 0:
+        return np.zeros(len(pts0), dtype=bool)
+
+    D = pairwise_sqdist(pts0, pts1)  # (N, M)
+
+    # nearest neighbor of each a_i in B, and of each b_j in A
+    j = np.argmin(D, axis=1).astype(np.int64)  # (N,)
+    i_back = np.argmin(D, axis=0).astype(np.int64)  # (M,)
+
+    idx = np.arange(len(pts0), dtype=np.int64)
+    keep = i_back[j] == idx  # mutual check
+
+    # distance check
+    dmin = D[idx, j]  # (N,)
+    keep &= dmin <= (eps * eps)
+
+    return keep
+
+
+def grid_nms_keep(pts, scores, cell=12):
+    """
+    One best match per (floor(x/cell), floor(y/cell)) bin.
+    Keeps index with largest score per bin.
+    """
+    if len(pts) == 0:
+        return np.zeros(0, dtype=bool)
+    bins = np.floor(pts / float(cell)).astype(int)
+    out = {}
+    for i, (bx, by) in enumerate(bins):
+        key = (bx, by)
+        if key not in out or scores[i] > scores[out[key]]:
+            out[key] = i
+    keep_idx = np.array(sorted(out.values()), dtype=int)
+    keep = np.zeros(len(pts), dtype=bool)
+    keep[keep_idx] = True
+    return keep
+
+
+# ------------------------- drawing -------------------------
+def draw_matches_side_by_side(imgA, imgB, ptsA, ptsB, conf=None, max_draw=1000):
+    A = imgA.copy()
+    B = imgB.copy()
+    if A.ndim == 2:
+        A = cv2.cvtColor(A, cv2.COLOR_GRAY2BGR)
+    if B.ndim == 2:
+        B = cv2.cvtColor(B, cv2.COLOR_GRAY2BGR)
+    h = max(A.shape[0], B.shape[0])
+    canvas = np.zeros((h, A.shape[1] + B.shape[1], 3), dtype=np.uint8)
+    canvas[: A.shape[0], : A.shape[1]] = A
+    canvas[: B.shape[0], A.shape[1] : A.shape[1] + B.shape[1]] = B
+
+    N = ptsA.shape[0]
+    order = np.arange(N) if conf is None else np.argsort(conf)[::-1]
+    order = order[: min(max_draw, N)]
+
+    offx = A.shape[1]
+    for i in order:
+        x0, y0 = ptsA[i]
+        x1, y1 = ptsB[i]
+        p0 = (int(round(x0)), int(round(y0)))
+        p1 = (int(round(x1 + offx)), int(round(y1)))
+        # points
+        cv2.circle(canvas, p0, 2, (0, 255, 0), -1)
+        cv2.circle(canvas, p1, 2, (0, 255, 0), -1)
+        # line
+        cv2.line(canvas, p0, p1, (0, 200, 255), 1, cv2.LINE_AA)
+    return canvas
+
+
+# ------------------------- inference wrapper -------------------------
+def run_infer(engine_path, img0_path, img1_path, size=832, norm="none"):
+    x0, img0_bgr_orig, img0_bgr_resz = load_rgb_tensor(
+        img0_path, (size, size), norm=norm
+    )
+    x1, img1_bgr_orig, img1_bgr_resz = load_rgb_tensor(
+        img1_path, (size, size), norm=norm
+    )
+    x0 = x0.cuda()
+    x1 = x1.cuda()
+    runner = TrtRunner(engine_path)
+    k0, k1, mconf = runner(x0, x1)
+    return k0, k1, mconf, (img0_bgr_orig, img1_bgr_orig), (img0_bgr_resz, img1_bgr_resz)
+
+
+# ------------------------- main -------------------------
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--engine", type=str, default="out/matchanything_final_complete.plan"
+    )
+    ap.add_argument("--img0", required=True)
+    ap.add_argument("--img1", required=True)
+    ap.add_argument("--size", type=int, default=832)
+    ap.add_argument(
+        "--norm", type=str, default="none", choices=["none", "imagenet", "neg_one_one"]
+    )
+
+    # confidence post-processing
+    ap.add_argument(
+        "--use_conf",
+        action="store_true",
+        help="If set, apply your own threshold to mconf; otherwise trust engine mask.",
+    )
+    ap.add_argument("--conf_th", type=float, default=0.05)
+    ap.add_argument(
+        "--topk", type=int, default=0, help="If >0, keep only top-K by mconf."
+    )
+
+    # matching cleanups
+    ap.add_argument(
+        "--mutual", action="store_true", help="Mutual NN filter in pixel space."
+    )
+    ap.add_argument(
+        "--eps", type=float, default=12.0, help="Max pixel distance for mutual NN."
+    )
+    ap.add_argument(
+        "--grid_nms", type=int, default=0, help="If >0, one best per cell (pixels)."
+    )
+
+    # other
+    ap.add_argument("--no_ransac", action="store_true", help="Skip RANSAC refinement.")
+    ap.add_argument(
+        "--swap_xy",
+        action="store_true",
+        help="Swap x/y columns in both keypoint arrays.",
+    )
+    ap.add_argument("--out", type=str, default="outputs")
+    args = ap.parse_args()
+
+    # Inference
+    k0, k1, mconf, (img0_bgr_orig, img1_bgr_orig), (img0_bgr_resz, img1_bgr_resz) = (
+        run_infer(args.engine, args.img0, args.img1, size=args.size, norm=args.norm)
+    )
+
+    print("TRT returned:", k0.shape, k1.shape, mconf.shape, "matches")
+    finite = np.isfinite(mconf)
+    print(
+        f"mconf stats: finite={finite.sum()}/{mconf.size}, "
+        f"min={np.nanmin(mconf):.6g}, max={np.nanmax(mconf):.6g}, mean={np.nanmean(mconf):.6g}"
+    )
+
+    # Optional axis swap (if your build exported (y,x) order)
+    if args.swap_xy:
+        k0 = k0[:, [1, 0]]
+        k1 = k1[:, [1, 0]]
+
+    pts0 = k0.copy()
+    pts1 = k1.copy()
+    scores = mconf.copy()
+
+    # Confidence threshold
+    if args.use_conf:
+        keep = np.isfinite(scores) & (scores >= args.conf_th)
+        print(
+            f"Kept {int(keep.sum())} / {len(scores)} matches @ conf_th={args.conf_th}"
+        )
+        if keep.any():
+            pts0 = pts0[keep]
+            pts1 = pts1[keep]
+            scores = scores[keep]
+        else:
+            print(
+                "[WARN] Threshold removed all matches; falling back to engine matches."
+            )
+
+    # Optional top-K
+    if args.topk and len(scores) > args.topk:
+        order = np.argsort(np.nan_to_num(scores, nan=-1.0))[::-1][: args.topk]
+        pts0 = pts0[order]
+        pts1 = pts1[order]
+        scores = scores[order]
+        print(f"Top-K: kept {len(scores)} matches")
+
+    # Mutual NN
+    if args.mutual and len(pts0) > 0:
+        keep = mutual_nn(pts0, pts1, eps=args.eps)
+        print(f"Mutual keep: {int(keep.sum())}/{len(pts0)}")
+        pts0 = pts0[keep]
+        pts1 = pts1[keep]
+        scores = scores[keep]
+
+    # Grid NMS on target image coords (deduplicate nearby lines)
+    if args.grid_nms and len(pts1) > 0:
+        keep = grid_nms_keep(pts1, scores, cell=int(args.grid_nms))
+        print(f"Grid-NMS({args.grid_nms}px): kept {int(keep.sum())}/{len(pts1)}")
+        pts0 = pts0[keep]
+        pts1 = pts1[keep]
+        scores = scores[keep]
+
+    # RANSAC homography (in resized/network space)
+    inliers = None
+    if not args.no_ransac and len(pts0) >= 8:
+        H, inliers = ransac_filter(pts0, pts1)
+        if inliers is not None and inliers.any():
+            print(f"RANSAC inliers: {inliers.sum()}/{len(inliers)}")
+        else:
+            print("RANSAC skipped or no inliers; using current matches.")
+            inliers = None
+    elif args.no_ransac:
+        print("RANSAC disabled.")
+    else:
+        print("Not enough points for RANSAC; using current matches.")
+
+    # Choose what to draw
+    if inliers is not None:
+        p0_draw = pts0[inliers]
+        p1_draw = pts1[inliers]
+        s_draw = scores[inliers]
+    else:
+        p0_draw = pts0
+        p1_draw = pts1
+        s_draw = scores
+
+    # Prepare mapping to original-size coords
+    h0o, w0o = img0_bgr_orig.shape[:2]
+    h1o, w1o = img1_bgr_orig.shape[:2]
+    sx0, sy0 = w0o / float(args.size), h0o / float(args.size)
+    sx1, sy1 = w1o / float(args.size), h1o / float(args.size)
+
+    # Draw (resized space)
+    vis_resized = draw_matches_side_by_side(
+        img0_bgr_resz, img1_bgr_resz, p0_draw, p1_draw, conf=s_draw, max_draw=1000
+    )
+
+    # Draw (original space)
+    p0_orig = np.stack([p0_draw[:, 0] * sx0, p0_draw[:, 1] * sy0], axis=1)
+    p1_orig = np.stack([p1_draw[:, 0] * sx1, p1_draw[:, 1] * sy1], axis=1)
+    vis_orig = draw_matches_side_by_side(
+        img0_bgr_orig, img1_bgr_orig, p0_orig, p1_orig, conf=s_draw, max_draw=1000
+    )
+
+    # Save
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem0 = Path(args.img0).stem
+    stem1 = Path(args.img1).stem
+    out_resz = out_dir / f"vis_resized_{stem0}_vs_{stem1}.png"
+    out_orig = out_dir / f"vis_{stem0}_vs_{stem1}.png"
+    ok1 = cv2.imwrite(str(out_resz), vis_resized)
+    ok2 = cv2.imwrite(str(out_orig), vis_orig)
+    print(f"[SAVE] Resized-space viz -> {out_resz} (ok={ok1})")
+    print(f"[SAVE] Original-size viz -> {out_orig} (ok={ok2})")
+
+
+if __name__ == "__main__":
+    main()

--- a/Convertion_Tensorrt/test_unified_weight_loading.py
+++ b/Convertion_Tensorrt/test_unified_weight_loading.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""
+Comprehensive test script for the unified weight loading system.
+
+This script tests the new unified weight loader against the MatchAnything checkpoint
+and validates that the DINOv2 weights are properly loaded.
+"""
+
+import os
+import sys
+
+
+def test_unified_loader_standalone():
+    """Test the unified weight loader in isolation"""
+    print("=" * 60)
+    print("TESTING UNIFIED WEIGHT LOADER (STANDALONE)")
+    print("=" * 60)
+
+    try:
+        from unified_weight_loader import apply_unified_weight_loading
+        from accurate_matchanything_trt import AccurateMatchAnythingTRT
+
+        # Create a model to get the expected state dict
+        print("[TEST] Creating model to get expected state dict...")
+        model = AccurateMatchAnythingTRT(
+            model_name="matchanything_roma",
+            img_resize=832,
+            match_threshold=0.1,
+            amp=False,
+        )
+        model_state_dict = model.state_dict()
+
+        print(f"[TEST] Model expects {len(model_state_dict)} parameters")
+
+        # Analyze model structure
+        dino_keys = [
+            k for k in model_state_dict.keys() if k.startswith("encoder.dino.")
+        ]
+        encoder_keys = [
+            k
+            for k in model_state_dict.keys()
+            if k.startswith("encoder.") and not k.startswith("encoder.dino.")
+        ]
+        matcher_keys = [k for k in model_state_dict.keys() if k.startswith("matcher.")]
+
+        print("[TEST] Model structure:")
+        print(f"  - DINOv2 parameters: {len(dino_keys)}")
+        print(f"  - CNN encoder parameters: {len(encoder_keys)}")
+        print(f"  - Matcher parameters: {len(matcher_keys)}")
+        print(
+            f"  - Other parameters: {len(model_state_dict) - len(dino_keys) - len(encoder_keys) - len(matcher_keys)}"
+        )
+
+        # Try to download checkpoint if it doesn't exist
+        checkpoint_path = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "../imcui/third_party/MatchAnything/weights/matchanything_roma.ckpt",
+            )
+        )
+
+        if not os.path.exists(checkpoint_path):
+            print(f"[TEST] Checkpoint not found at {checkpoint_path}")
+            print("[TEST] Attempting to download...")
+            try:
+                from download_weights import download_matchanything_weights
+
+                checkpoint_path = download_matchanything_weights(
+                    output_dir=os.path.dirname(checkpoint_path), force_download=False
+                )
+            except Exception as e:
+                print(f"[TEST] Failed to download checkpoint: {e}")
+                print("[TEST] Skipping checkpoint-based tests...")
+                return False
+
+        if os.path.exists(checkpoint_path):
+            print(f"[TEST] Using checkpoint: {checkpoint_path}")
+
+            # Test the unified loader
+            print("\n[TEST] Testing unified weight loader...")
+            loadable = apply_unified_weight_loading(
+                checkpoint_path, model_state_dict, load_dinov2_components=True
+            )
+
+            # Analyze results
+            loaded_dino = sum(
+                1 for k in loadable.keys() if k.startswith("encoder.dino.")
+            )
+            loaded_encoder = sum(
+                1
+                for k in loadable.keys()
+                if k.startswith("encoder.") and not k.startswith("encoder.dino.")
+            )
+            loaded_matcher = sum(1 for k in loadable.keys() if k.startswith("matcher."))
+
+            print("\n[TEST] Loading results:")
+            print(
+                f"  - Total loaded: {len(loadable)} / {len(model_state_dict)} ({100.0 * len(loadable) / len(model_state_dict):.1f}%)"
+            )
+            print(
+                f"  - DINOv2 loaded: {loaded_dino} / {len(dino_keys)} ({100.0 * loaded_dino / max(len(dino_keys), 1):.1f}%)"
+            )
+            print(
+                f"  - CNN encoder loaded: {loaded_encoder} / {len(encoder_keys)} ({100.0 * loaded_encoder / max(len(encoder_keys), 1):.1f}%)"
+            )
+            print(
+                f"  - Matcher loaded: {loaded_matcher} / {len(matcher_keys)} ({100.0 * loaded_matcher / max(len(matcher_keys), 1):.1f}%)"
+            )
+
+            # Check for critical components
+            critical_components = [
+                "encoder.dino.pos_embed",
+                "encoder.dino.cls_token",
+                "encoder.dino.patch_embed.proj.weight",
+                "encoder.dino.blocks.0.0.norm1.weight",  # First transformer block
+            ]
+
+            print("\n[TEST] Critical component check:")
+            for component in critical_components:
+                if component in loadable:
+                    shape = loadable[component].shape
+                    print(f"  ✅ {component}: {shape}")
+                else:
+                    print(f"  ❌ {component}: MISSING")
+
+            # Success criteria
+            success = len(loadable) >= 0.8 * len(model_state_dict)
+            dino_success = (
+                loaded_dino >= 0.8 * len(dino_keys) if len(dino_keys) > 0 else True
+            )
+
+            print("\n[TEST] Success criteria:")
+            print(f"  - Overall loading (>80%): {'✅' if success else '❌'}")
+            print(f"  - DINOv2 loading (>80%): {'✅' if dino_success else '❌'}")
+
+            return success and dino_success
+
+        else:
+            print("[TEST] No checkpoint available for testing")
+            return False
+
+    except Exception as e:
+        print(f"[TEST] Error in standalone test: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def main():
+    """Run all tests for the unified weight loading system"""
+    print("🧪 TESTING UNIFIED WEIGHT LOADING SYSTEM")
+    print("=" * 80)
+
+    results = {}
+
+    # Test 1: Standalone loader test
+    print("\n" + "=" * 20 + " TEST 1 " + "=" * 20)
+    results["standalone"] = test_unified_loader_standalone()
+
+    # Summary
+    print("\n" + "=" * 80)
+    print("SUMMARY")
+    print("=" * 80)
+
+    for test_name, passed in results.items():
+        status = "✅ PASSED" if passed else "❌ FAILED"
+        print(f"  {test_name.upper():15} : {status}")
+
+    all_passed = all(results.values())
+
+    print(
+        f"\nOverall result: {'✅ ALL TESTS PASSED' if all_passed else '❌ SOME TESTS FAILED'}"
+    )
+
+    if all_passed:
+        print("\n🎉 SUCCESS: The unified weight loading system is working correctly!")
+        print("   - DINOv2 weights should be properly loaded")
+        print("   - ONNX export should include all model weights")
+        print(
+            "   - TensorRT engine built from this ONNX should be much larger and more accurate"
+        )
+    else:
+        print("\n⚠️  Issues detected with the unified weight loading system.")
+        print("   Please check the error messages above for details.")
+
+    return all_passed
+
+
+if __name__ == "__main__":
+    success = main()
+    sys.exit(0 if success else 1)

--- a/Convertion_Tensorrt/unified_weight_loader.py
+++ b/Convertion_Tensorrt/unified_weight_loader.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+"""Unified weight loading helper reused across export scripts."""
+
+from Convertion_Tensorrt_new.export_dynamic_onnx_unified import (
+    apply_unified_weight_loading,
+)  # noqa: F401

--- a/Convertion_Tensorrt_new/accurate_matchanything_trt_dyn.py
+++ b/Convertion_Tensorrt_new/accurate_matchanything_trt_dyn.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Accurate MatchAnything (ROMA-style) for ONNX/TensorRT (dynamic HxW).
+- Pads inside the graph to the next multiple of encoder.patch (e.g., 16).
+- Returns dense fields: warp_c [B,Ha,Wa,2], cert_c [B,Ha,Wa]
+- Also returns: valid_mask [B,Ha,Wa] (1 real, 0 padded), coarse_stride [1] (float)
+- No in-graph thresholding; host filters/top-K.
+"""
+
+from typing import Dict, Tuple
+import sys
+from pathlib import Path
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+# --- allow importing modules from your old folder (Convertion_Tensorrt) ---
+_THIS_DIR = Path(__file__).resolve().parent
+_OLD_DIR = _THIS_DIR.parent / "Convertion_Tensorrt"
+if _OLD_DIR.exists() and str(_OLD_DIR) not in sys.path:
+    sys.path.insert(0, str(_OLD_DIR))
+# -------------------------------------------------------------------------
+
+from encoders_trt_full import CNNandDinov2TRT
+from gp_trt import GPMatchEncoderTRT
+
+
+def _pad_to_multiple(x: torch.Tensor, mult: int) -> Tuple[torch.Tensor, int, int]:
+    """Right/bottom pad to make H,W multiples of mult. Return (padded, pad_h, pad_w)."""
+    B, C, H, W = x.shape
+    pad_h = (mult - (H % mult)) % mult
+    pad_w = (mult - (W % mult)) % mult
+    if pad_h == 0 and pad_w == 0:
+        return x, 0, 0
+    # pad format: (left, right, top, bottom)
+    return F.pad(x, (0, pad_w, 0, pad_h)), pad_h, pad_w
+
+
+class AccurateMatchAnythingTRT(nn.Module):
+    def __init__(self, amp: bool = False):
+        super().__init__()
+        self.encoder = CNNandDinov2TRT(amp=amp)  # has .patch (your enc asserts 16)
+        self.matcher = GPMatchEncoderTRT(beta=10.0)  # ROMA-style GP matcher
+
+    def forward(
+        self, image0: torch.Tensor, image1: torch.Tensor
+    ) -> Dict[str, torch.Tensor]:
+        """
+        Inputs: image0, image1 -> [B,3,H,W] RGB float in [0,1], any H,W
+        Outputs:
+            warp_c        [B,Ha,Wa,2]  coarse coords (x,y) in img1
+            cert_c        [B,Ha,Wa]
+            valid_mask    [B,Ha,Wa]    1 for real image area, 0 for padded
+            coarse_stride [1]  (float) encoder patch/stride (e.g., 16.)
+        """
+        B, C, H, W = image0.shape
+        patch = int(getattr(self.encoder, "patch", 16))
+
+        # RGB->Gray inside graph (ONNX-friendly)
+        img0_gray = (
+            0.299 * image0[:, 0:1] + 0.587 * image0[:, 1:2] + 0.114 * image0[:, 2:3]
+        )
+        img1_gray = (
+            0.299 * image1[:, 0:1] + 0.587 * image1[:, 1:2] + 0.114 * image1[:, 2:3]
+        )
+
+        # Pad to multiple-of-patch
+        img0p, _, _ = _pad_to_multiple(img0_gray, patch)
+        img1p, _, _ = _pad_to_multiple(img1_gray, patch)
+
+        # Coarse features (stride=patch)
+        feat0 = self.encoder(img0p)["coarse"]  # [B,Cc,Ha,Wa]
+        feat1 = self.encoder(img1p)["coarse"]  # [B,Cc,Ha,Wa]
+
+        # Dense matching
+        warp_c, cert_c = self.matcher(feat0, feat1)  # [B,Ha,Wa,2], [B,Ha,Wa]
+        _, Ha, Wa, _ = warp_c.shape
+
+        # Valid coarse mask for original extent (ignore padded coarse cells)
+        yy = torch.arange(Ha, device=warp_c.device).view(1, Ha, 1).float()
+        xx = torch.arange(Wa, device=warp_c.device).view(1, 1, Wa).float()
+        valid_y = (yy * patch) < float(H)
+        valid_x = (xx * patch) < float(W)
+        valid_mask = (valid_y & valid_x).to(cert_c.dtype).expand(B, Ha, Wa)
+
+        # Stride as tensor (export-friendly)
+        coarse_stride = torch.tensor(
+            [float(patch)], device=warp_c.device, dtype=warp_c.dtype
+        )
+
+        return {
+            "warp_c": warp_c,
+            "cert_c": cert_c,
+            "valid_mask": valid_mask,
+            "coarse_stride": coarse_stride,
+        }

--- a/Convertion_Tensorrt_new/export_dense_onnx.py
+++ b/Convertion_Tensorrt_new/export_dense_onnx.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Export MatchAnything (ROMA) to ONNX with dense outputs (warp_c, cert_c).
+
+Notes:
+  • Inputs:  image0, image1   -> [B,3,H,W], float32 in [0,1]
+  • Outputs: warp_c            -> [B,Ha,Wa,2]  (coarse grid coords in image1, Ha=H/14, Wa=W/14)
+            cert_c            -> [B,Ha,Wa]
+  • Dynamic axes: B, H, W, Ha, Wa
+  • No in-graph thresholding, no variable-length lists.
+"""
+
+import os
+import inspect
+import torch
+import onnx
+
+from Convertion_Tensorrt_new.accurate_matchanything_trt_dyn import (
+    AccurateMatchAnythingTRT,
+)
+
+
+# Optional: your weight mapping loader (if available)
+def _try_load_weights(model, ckpt_path: str):
+    if ckpt_path and os.path.exists(ckpt_path):
+        try:
+            # Your full unified loader module name if present in your repo
+            from unified_weight_loader_complete import apply_unified_weight_loading
+
+            model_state = model.state_dict()
+            loadable = apply_unified_weight_loading(
+                ckpt_path, model_state, load_dinov2_components=True
+            )
+            missing, unexpected = model.load_state_dict(loadable, strict=False)
+            print(
+                f"[WEIGHTS] Loaded={len(loadable)}, missing={len(missing)}, unexpected={len(unexpected)}"
+            )
+        except Exception as e:
+            print(f"[WEIGHTS] Failed unified loader: {e}")
+            print(
+                "[WEIGHTS] Proceeding WITHOUT weights (random init) — expect low scores."
+            )
+    else:
+        print("[WEIGHTS] No checkpoint file given; continuing without weights.")
+
+
+def export_onnx(onnx_path: str, ckpt: str = "", H: int = 840, W: int = 840):
+    device = "cpu"
+    model = AccurateMatchAnythingTRT(amp=False).to(device).eval()
+    _try_load_weights(model, ckpt)
+
+    # Dummy inputs — pick multiples of 14 (e.g., 840 = 60*14)
+    x0 = torch.rand(1, 3, H, W, device=device)
+    x1 = torch.rand(1, 3, H, W, device=device)
+
+    # Dry run
+    with torch.inference_mode():
+        out = model(x0, x1)
+        print("Dry run:", out["warp_c"].shape, out["cert_c"].shape)
+
+    dynamic_axes = {
+        "image0": {"0": "B", "2": "H", "3": "W"},
+        "image1": {"0": "B", "2": "H", "3": "W"},
+        "warp_c": {"0": "B", "1": "Ha", "2": "Wa"},
+        "cert_c": {"0": "B", "1": "Ha", "2": "Wa"},
+    }
+
+    export_kwargs = dict(
+        input_names=["image0", "image1"],
+        output_names=["warp_c", "cert_c"],
+        dynamic_axes=dynamic_axes,
+        opset_version=17,
+        do_constant_folding=True,
+        verbose=False,
+    )
+    if "use_external_data_format" in inspect.signature(torch.onnx.export).parameters:
+        export_kwargs["use_external_data_format"] = True
+
+    os.makedirs(os.path.dirname(onnx_path) or ".", exist_ok=True)
+    torch.onnx.export(model, (x0, x1), onnx_path, **export_kwargs)
+    print(f"[ONNX] Saved -> {onnx_path}")
+
+    # (Optional) consolidate external data if created by exporter
+    try:
+        model_proto = onnx.load(onnx_path, load_external_data=True)
+        onnx.save_model(model_proto, onnx_path, save_as_external_data=True)
+    except Exception as e:
+        print(f"[ONNX] External data consolidation skipped: {e}")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--onnx", default="out/matchanything_dense.onnx")
+    ap.add_argument("--ckpt", default="")
+    ap.add_argument("--H", type=int, default=840, help="Multiple of 14")
+    ap.add_argument("--W", type=int, default=840, help="Multiple of 14")
+    args = ap.parse_args()
+    export_onnx(args.onnx, args.ckpt, args.H, args.W)

--- a/Convertion_Tensorrt_new/export_dynamic_onnx_unified.py
+++ b/Convertion_Tensorrt_new/export_dynamic_onnx_unified.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""
+Export dynamic ONNX for MatchAnything with unified weight loading & full stats.
+
+Outputs (dense, no filtering):
+  - warp_c        [B,Ha,Wa,2]
+  - cert_c        [B,Ha,Wa]
+  - valid_mask    [B,Ha,Wa]
+  - coarse_stride [1]  (float)
+
+Dynamic axes for B,H,W,Ha,Wa. Compatible with TensorRT dynamic profiles.
+"""
+
+import os
+import re
+import inspect
+import sys
+import tempfile
+from contextlib import contextmanager, redirect_stdout, redirect_stderr
+from pathlib import Path
+from typing import Dict, List, Tuple
+import numpy as np
+import torch
+import torch.nn.functional as F
+import onnx
+
+# Optional timm (for DINOv2 backfill). If missing, we continue.
+try:
+    import timm
+except Exception:
+    timm = None
+
+_THIS_DIR = Path(__file__).resolve().parent
+if str(_THIS_DIR) not in os.sys.path:
+    os.sys.path.insert(0, str(_THIS_DIR))
+
+from accurate_matchanything_trt_dyn import AccurateMatchAnythingTRT
+
+
+# ---------------------------------------------------------------------
+# Low-level (C/C++) stdout/stderr silencer (captures libtorch/ONNX prints)
+# ---------------------------------------------------------------------
+@contextmanager
+def silence_stdio_c(stdout=True, stderr=True):
+    """
+    Temporarily redirect OS-level file descriptors for stdout/stderr to a
+    temporary file so C/C++ prints (libtorch/JIT/ONNX) are hidden.
+
+    NOTE: Python-level redirect_* only captures Python writes; C++ writes need
+    fd redirection (os.dup2) as described by pybind11 & others.
+    """
+    fds = []
+    backups = []
+    tmp = None
+    try:
+        if not (stdout or stderr):
+            yield
+            return
+
+        # Flush Python streams so we don't lose ordering
+        sys.stdout.flush()
+        sys.stderr.flush()
+
+        tmp = tempfile.TemporaryFile(mode="w+b")
+        if stdout:
+            backups.append((1, os.dup(1)))
+            fds.append(1)
+        if stderr:
+            backups.append((2, os.dup(2)))
+            fds.append(2)
+
+        for fd in fds:
+            os.dup2(tmp.fileno(), fd)
+
+        yield
+    finally:
+        try:
+            # Restore original fds
+            for fd, bk in backups:
+                os.dup2(bk, fd)
+                os.close(bk)
+        finally:
+            if tmp is not None:
+                tmp.close()
+
+
+# -----------------------------
+# Unified weight loading
+# -----------------------------
+def create_comprehensive_mapping_rules() -> List[Tuple[re.Pattern, str]]:
+    return [
+        (re.compile(r"^module\."), ""),
+        (re.compile(r"^_orig_mod\."), ""),
+        (re.compile(r"^matcher\.model\.decoder\.embedding_decoder\."), "encoder.dino."),
+        (re.compile(r"^embedding_decoder\."), "encoder.dino."),
+        (re.compile(r"^decoder\.embedding_decoder\."), "encoder.dino."),
+        (re.compile(r"^matcher\.model\.encoder\.cnn\.layers\."), "encoder.layers."),
+        (re.compile(r"^matcher\.model\.encoder\.cnn\."), "encoder."),
+        (re.compile(r"^matcher\.model\.encoder\."), "encoder."),
+        (re.compile(r"^matcher\.model\.decoder\."), "matcher."),
+        (re.compile(r"^matcher\.model\."), ""),
+        (re.compile(r"^matcher\."), ""),
+        (re.compile(r"^model\."), ""),
+        (re.compile(r"^backbone\."), "encoder.dino."),
+        (re.compile(r"^vit\."), "encoder.dino."),
+        (re.compile(r"^dino\."), "encoder.dino."),
+        (re.compile(r"^encoder\.vit\."), "encoder.dino."),
+        (re.compile(r"^encoder\.backbone\."), "encoder.dino."),
+        (re.compile(r"^encoder\.dino\."), "encoder.dino."),
+        (re.compile(r"^encoder\."), "encoder."),
+    ]
+
+
+def fix_dinov2_block_structure(
+    weights_dict: Dict[str, torch.Tensor],
+) -> Dict[str, torch.Tensor]:
+    """Convert 'encoder.dino.blocks.N.*' -> 'encoder.dino.blocks.0.N.*' for BlockChunk."""
+    fixed = {}
+    for k, v in weights_dict.items():
+        if k.startswith("encoder.dino.blocks."):
+            parts = k.split(".")
+            if len(parts) >= 4 and parts[3].isdigit():
+                blk = parts[3]
+                if len(parts) >= 5 and parts[4].isdigit():
+                    fixed[k] = v
+                else:
+                    new_key = ".".join(parts[:3] + ["0", blk] + parts[4:])
+                    fixed[new_key] = v
+                    print(f"[LOAD] BlockChunk fix: {k} -> {new_key}")
+            else:
+                fixed[k] = v
+        else:
+            fixed[k] = v
+    return fixed
+
+
+def resize_positional_embedding(
+    pos_embed: torch.Tensor, target_size: int
+) -> torch.Tensor:
+    if pos_embed.shape[1] == target_size:
+        print(f"[LOAD] pos_embed already {tuple(pos_embed.shape)}")
+        return pos_embed
+    print(
+        f"[LOAD] Resize pos_embed {tuple(pos_embed.shape)} -> [1,{target_size},{pos_embed.shape[2]}]"
+    )
+    cls = pos_embed[:, 0:1, :]
+    spatial = pos_embed[:, 1:, :]
+    nsp = spatial.shape[1]
+    og = int(np.sqrt(nsp))
+    assert og * og == nsp, f"pos_embed spatial tokens not square: {nsp}"
+    tg_spatial = target_size - 1
+    tg = int(np.sqrt(tg_spatial))
+    assert tg * tg == tg_spatial, f"target size {target_size} not square+1"
+    D = spatial.shape[2]
+    spatial_2d = spatial.reshape(1, og, og, D).permute(0, 3, 1, 2)  # [1,D,H,W]
+    resized = F.interpolate(
+        spatial_2d, size=(tg, tg), mode="bilinear", align_corners=False
+    )
+    resized = resized.permute(0, 2, 3, 1).reshape(1, tg_spatial, D)
+    out = torch.cat([cls, resized], dim=1)
+    return out
+
+
+def load_dinov2_components(
+    model_state: Dict[str, torch.Tensor],
+) -> Dict[str, torch.Tensor]:
+    """Optional fill-ins from official DINOv2 timm weights."""
+    out = {}
+    if timm is None:
+        print("[LOAD] timm not available; skipping DINOv2 backfill")
+        return out
+    try:
+        print("[LOAD] Loading DINOv2 (timm) for missing components...")
+        dinom = timm.create_model("vit_large_patch14_dinov2.lvd142m", pretrained=True)
+        official = dinom.state_dict()
+
+        if "encoder.dino.pos_embed" in model_state and "pos_embed" in official:
+            pos = official["pos_embed"]
+            tgt = model_state["encoder.dino.pos_embed"]
+            if pos.shape != tgt.shape:
+                pos = resize_positional_embedding(pos, tgt.shape[1])
+            out["encoder.dino.pos_embed"] = pos
+            print(f"[LOAD] +pos_embed {tuple(pos.shape)}")
+
+        # If the ckpt didn't have these at all, synthesize or copy from timm
+        if "encoder.dino.cls_token" in model_state:
+            out["encoder.dino.cls_token"] = official.get(
+                "cls_token", torch.zeros_like(model_state["encoder.dino.cls_token"])
+            )
+            print(f"[LOAD] +cls_token {tuple(out['encoder.dino.cls_token'].shape)}")
+        if "encoder.dino.mask_token" in model_state:
+            out["encoder.dino.mask_token"] = official.get(
+                "mask_token", torch.zeros_like(model_state["encoder.dino.mask_token"])
+            )
+            src = "timm" if "mask_token" in official else "synthesized zeros"
+            print(
+                f"[LOAD] +mask_token ({src}) {tuple(out['encoder.dino.mask_token'].shape)}"
+            )
+
+        need_patch = any(
+            k.startswith("encoder.dino.patch_embed.") for k in model_state.keys()
+        )
+        if need_patch:
+            for k, v in official.items():
+                if k.startswith("patch_embed."):
+                    nk = f"encoder.dino.{k}"
+                    if nk in model_state:
+                        out[nk] = v
+                        print(f"[LOAD] +{nk} {tuple(v.shape)}")
+
+        # If final LayerNorm params are totally missing, mirror from official or zeros
+        if (
+            "encoder.dino.norm.weight" in model_state
+            and "encoder.dino.norm.weight" not in out
+        ):
+            out["encoder.dino.norm.weight"] = official.get(
+                "norm.weight", torch.ones_like(model_state["encoder.dino.norm.weight"])
+            )
+            print(
+                f"[LOAD] +encoder.dino.norm.weight {tuple(out['encoder.dino.norm.weight'].shape)}"
+            )
+        if (
+            "encoder.dino.norm.bias" in model_state
+            and "encoder.dino.norm.bias" not in out
+        ):
+            out["encoder.dino.norm.bias"] = official.get(
+                "norm.bias", torch.zeros_like(model_state["encoder.dino.norm.bias"])
+            )
+            print(
+                f"[LOAD] +encoder.dino.norm.bias {tuple(out['encoder.dino.norm.bias'].shape)}"
+            )
+
+    except Exception as e:
+        print(f"[LOAD] DINOv2 backfill failed: {e}")
+    return out
+
+
+def load_missing_dinov2_blocks(
+    model_state: Dict[str, torch.Tensor], existing: Dict[str, torch.Tensor]
+) -> Dict[str, torch.Tensor]:
+    """Fill missing transformer blocks from official DINOv2 (wrap-around if needed)."""
+    out = {}
+    if timm is None:
+        print("[LOAD] timm not available; skipping missing-block fill")
+        return out
+    try:
+        print("[LOAD] Filling missing DINOv2 blocks from timm...")
+        dinom = timm.create_model("vit_large_patch14_dinov2.lvd142m", pretrained=True)
+        official = dinom.state_dict()
+
+        need, have = set(), set()
+        for k in model_state.keys():
+            if k.startswith("encoder.dino.blocks.0.") and len(k.split(".")) >= 5:
+                blk = k.split(".")[4]
+                if blk.isdigit():
+                    need.add(int(blk))
+        for k in existing.keys():
+            if k.startswith("encoder.dino.blocks.0.") and len(k.split(".")) >= 5:
+                blk = k.split(".")[4]
+                if blk.isdigit():
+                    have.add(int(blk))
+        miss = need - have
+        print(f"[LOAD] Need blocks: {sorted(need)}")
+        print(f"[LOAD] Have blocks: {sorted(have)}")
+        print(f"[LOAD] Missing:     {sorted(miss)}")
+
+        for mb in sorted(miss):
+            src = mb % 24  # wrap if needed
+            for ok, ov in official.items():
+                if ok.startswith(f"blocks.{src}."):
+                    comps = ok.split(".")[2:]  # drop 'blocks.N'
+                    nk = f"encoder.dino.blocks.0.{mb}." + ".".join(comps)
+                    if nk in model_state:
+                        out[nk] = ov
+        print(f"[LOAD] Added {len(out)} missing block params")
+    except Exception as e:
+        print(f"[LOAD] Missing-block fill failed: {e}")
+    return out
+
+
+def apply_unified_weight_loading(
+    checkpoint_path: str,
+    model_state: Dict[str, torch.Tensor],
+    use_dinov2_backfill: bool = True,
+) -> Dict[str, torch.Tensor]:
+    print(f"[LOAD] Reading checkpoint: {checkpoint_path}")
+    try:
+        raw = torch.load(checkpoint_path, map_location="cpu")
+        ckpt_state = raw.get("state_dict", raw)
+    except Exception as e:
+        print(f"[LOAD] ERROR loading checkpoint: {e}")
+        return {}
+
+    print(f"[LOAD] CKPT keys: {len(ckpt_state)}")
+    print(f"[LOAD] Model expects keys: {len(model_state)}")
+
+    # Step 1: map keys
+    rules = create_comprehensive_mapping_rules()
+    mapped = {}
+    for k, v in ckpt_state.items():
+        nk = k
+        for pat, rep in rules:
+            nk = pat.sub(rep, nk)
+        mapped[nk] = v
+    print(f"[LOAD] After mapping: {len(mapped)}")
+
+    # Step 2: DINO BlockChunk structure
+    mapped = fix_dinov2_block_structure(mapped)
+
+    # Step 3: optional backfill from official DINOv2
+    if use_dinov2_backfill:
+        back = load_dinov2_components(model_state)
+        mapped.update(back)
+
+    # Step 4: direct matches
+    loadable: Dict[str, torch.Tensor] = {}
+    for mk, mv in model_state.items():
+        if mk in mapped and mapped[mk].shape == mv.shape:
+            loadable[mk] = mapped[mk]
+    print(f"[LOAD] Direct matches: {len(loadable)}")
+
+    # Step 5: fill missing blocks
+    if use_dinov2_backfill:
+        add_blocks = load_missing_dinov2_blocks(model_state, loadable)
+        loadable.update(add_blocks)
+        print(f"[LOAD] After missing-block fill: {len(loadable)}")
+
+    # Step 6: final backfill for qkv.bias (paramwise copy by block index)
+    if use_dinov2_backfill and timm is not None:
+        try:
+            dinom = timm.create_model(
+                "vit_large_patch14_dinov2.lvd142m", pretrained=True
+            )
+            official = dinom.state_dict()
+            for b in range(24):
+                mk = f"encoder.dino.blocks.0.{b}.attn.qkv.bias"
+                ok = f"blocks.{b}.attn.qkv.bias"
+                if (
+                    mk in model_state
+                    and mk not in loadable
+                    and ok in official
+                    and official[ok].shape == model_state[mk].shape
+                ):
+                    loadable[mk] = official[ok]
+                    print(f"[LOAD] +paramwise {mk}  (from {ok})")
+            print(f"[LOAD] After paramwise fill: {len(loadable)}")
+        except Exception as e:
+            print(f"[LOAD] Paramwise fill failed: {e}")
+
+    # Report
+    loaded_cnt = len(loadable)
+    total_cnt = len(model_state)
+    pct = 100.0 * loaded_cnt / max(1, total_cnt)
+    print("[LOAD] === SUMMARY ===")
+    print(f"[LOAD] Loaded tensors: {loaded_cnt} / {total_cnt}  ({pct:.1f}%)")
+
+    # DINO block coverage
+    blocks_loaded = set()
+    for k in loadable.keys():
+        if k.startswith("encoder.dino.blocks.0.") and len(k.split(".")) >= 5:
+            b = k.split(".")[4]
+            if b.isdigit():
+                blocks_loaded.add(int(b))
+    print(f"[LOAD] DINOv2 blocks loaded: {len(blocks_loaded)}/24")
+
+    if loaded_cnt >= 0.95 * total_cnt:
+        print("[LOAD] ✅ SUCCESS: >95% loaded")
+    elif loaded_cnt >= 0.8 * total_cnt:
+        print("[LOAD] ⚠️  WARNING: 80–95% loaded")
+    else:
+        print("[LOAD] ❌ ERROR: <80% loaded")
+
+    return loadable
+
+
+# -----------------------------
+# Export
+# -----------------------------
+def export_onnx(
+    onnx_path: str,
+    ckpt: str = "",
+    H: int = 768,
+    W: int = 1024,
+    use_dinov2_backfill: bool = True,
+    verbose_export: bool = False,
+    silence_cpp: bool = True,
+):
+    # Keep logs quieter unless asked
+    os.environ.pop("PYTORCH_ONNX_VERBOSE", None)
+    os.environ.pop("PYTORCH_JIT_LOG_LEVEL", None)
+    os.environ.pop("TORCH_LOGS", None)
+
+    device = "cpu"
+    model = AccurateMatchAnythingTRT(amp=False).to(device).eval()
+
+    # Load weights
+    if ckpt and os.path.exists(ckpt):
+        ms = model.state_dict()
+        loadable = apply_unified_weight_loading(ckpt, ms, use_dinov2_backfill)
+        missing, unexpected = model.load_state_dict(loadable, strict=False)
+        print(
+            f"[LOAD] load_state_dict -> loaded={len(loadable)}, missing={len(missing)}, unexpected={len(unexpected)}"
+        )
+        if missing:
+            print("[LOAD] --- Missing keys ---")
+            for k in sorted(missing):
+                print("   ", k)
+        if unexpected:
+            print("[LOAD] --- Unexpected keys ---")
+            for k in sorted(unexpected):
+                print("   ", k)
+    else:
+        print(
+            "[LOAD] No checkpoint provided or file missing; continuing with random init (low scores)."
+        )
+
+    # Dummy input
+    x0 = torch.rand(1, 3, H, W, device=device)
+    x1 = torch.rand(1, 3, H, W, device=device)
+
+    # Dry run
+    with torch.inference_mode():
+        out = model(x0, x1)
+        print(
+            "Dry run:",
+            "warp_c",
+            tuple(out["warp_c"].shape),
+            "cert_c",
+            tuple(out["cert_c"].shape),
+            "valid_mask",
+            tuple(out["valid_mask"].shape),
+            "coarse_stride",
+            tuple(out["coarse_stride"].shape),
+        )
+
+    out_path = Path(onnx_path).expanduser().resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    dynamic_axes = {
+        "image0": {"0": "B", "2": "H", "3": "W"},
+        "image1": {"0": "B", "2": "H", "3": "W"},
+        "warp_c": {"0": "B", "1": "Ha", "2": "Wa"},
+        "cert_c": {"0": "B", "1": "Ha", "2": "Wa"},
+        "valid_mask": {"0": "B", "1": "Ha", "2": "Wa"},
+        "coarse_stride": {"0": "one"},
+    }
+
+    kwargs = dict(
+        input_names=["image0", "image1"],
+        output_names=["warp_c", "cert_c", "valid_mask", "coarse_stride"],
+        dynamic_axes=dynamic_axes,
+        opset_version=17,
+        do_constant_folding=True,
+        verbose=bool(verbose_export),
+        training=torch.onnx.TrainingMode.EVAL,
+    )
+    if "use_external_data_format" in inspect.signature(torch.onnx.export).parameters:
+        kwargs["use_external_data_format"] = True  # safer for very large models
+
+    # Export with both Python-level and OS-level silencing
+    try:
+        with (
+            redirect_stdout(open(os.devnull, "w")),
+            redirect_stderr(open(os.devnull, "w")),
+        ):
+            ctx = (
+                silence_stdio_c(stdout=True, stderr=True)
+                if silence_cpp
+                else contextmanager(lambda: (yield))()
+            )
+            with ctx:
+                torch.onnx.export(model, (x0, x1), str(out_path), **kwargs)
+    except Exception as e:
+        # Make sure the error is visible even if we were silencing
+        sys.stdout.flush()
+        sys.stderr.flush()
+        print(f"[ONNX] EXPORT FAILED: {e}")
+        raise
+
+    # Verify file exists and is readable
+    if not out_path.exists():
+        raise FileNotFoundError(f"[ONNX] Expected file not found: {out_path}")
+
+    size_mb = out_path.stat().st_size / (1024 * 1024.0)
+    print(f"[ONNX] Saved -> {out_path}  ({size_mb:.1f} MB)")
+
+    # Load with onnx to sanity-check
+    try:
+        mp = onnx.load(str(out_path), load_external_data=True)
+        print(
+            f"[ONNX] Model loaded OK: ir_version={mp.ir_version}, opsets={[ (o.domain,o.version) for o in mp.opset_import ]}"
+        )
+    except Exception as e:
+        print(f"[ONNX] WARNING: onnx.load failed: {e}")
+
+    return str(out_path)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser(
+        description="Export dynamic ONNX with unified weight loading"
+    )
+    ap.add_argument("--onnx", default="out/matchanything_dense_dynamic.onnx")
+    ap.add_argument(
+        "--ckpt",
+        default="/home/mathias/MatchAnything/imcui/third_party/MatchAnything/weights/matchanything_roma.ckpt",
+    )
+    ap.add_argument("--H", type=int, default=768)
+    ap.add_argument("--W", type=int, default=1024)
+    ap.add_argument(
+        "--no_dinov2_backfill", action="store_true", help="Disable DINOv2 timm backfill"
+    )
+    ap.add_argument(
+        "--verbose_export",
+        action="store_true",
+        help="ONNX exporter verbose graph print",
+    )
+    ap.add_argument(
+        "--no_silence_cpp",
+        action="store_true",
+        help="Do not silence C++ stdout/stderr during export",
+    )
+    args = ap.parse_args()
+
+    export_onnx(
+        onnx_path=args.onnx,
+        ckpt=args.ckpt,
+        H=args.H,
+        W=args.W,
+        use_dinov2_backfill=not args.no_dinov2_backfill,
+        verbose_export=args.verbose_export,
+        silence_cpp=not args.no_silence_cpp,
+    )

--- a/Convertion_Tensorrt_new/run_trt_dense.py
+++ b/Convertion_Tensorrt_new/run_trt_dense.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+import numpy as np
+import cv2
+import torch
+import tensorrt as trt
+
+TRT_LOGGER = trt.Logger(trt.Logger.INFO)
+
+
+def ceil_mul14(x):  # smallest multiple of 14 >= x
+    return ((x + 13) // 14) * 14
+
+
+def load_rgb_tensor(path, size=None):
+    """Read BGR, -> RGB float32 [0,1], resize to (size,size) if given (rounded up to multiple-of-14)."""
+    img_bgr = cv2.imread(str(path), cv2.IMREAD_COLOR)
+    if img_bgr is None:
+        raise FileNotFoundError(path)
+    if size is not None:
+        size14 = ceil_mul14(size)
+        img_bgr = cv2.resize(
+            img_bgr, (size14, size14), interpolation=cv2.INTER_LANCZOS4
+        )
+    img_rgb = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0
+    t = (
+        torch.from_numpy(np.transpose(img_rgb, (2, 0, 1))[None, ...])
+        .contiguous()
+        .float()
+    )
+    return t, img_bgr
+
+
+def draw_matches_side_by_side(imgA, imgB, ptsA, ptsB, conf=None, max_draw=1000):
+    A = imgA.copy()
+    B = imgB.copy()
+    if A.ndim == 2:
+        A = cv2.cvtColor(A, cv2.COLOR_GRAY2BGR)
+    if B.ndim == 2:
+        B = cv2.cvtColor(B, cv2.COLOR_GRAY2BGR)
+    H = max(A.shape[0], B.shape[0])
+    canvas = np.zeros((H, A.shape[1] + B.shape[1], 3), dtype=np.uint8)
+    canvas[: A.shape[0], : A.shape[1]] = A
+    canvas[: B.shape[0], A.shape[1] : A.shape[1] + B.shape[1]] = B
+    offx = A.shape[1]
+    N = ptsA.shape[0]
+    if conf is not None:
+        order = np.argsort(np.nan_to_num(conf, nan=-1.0))[::-1]
+    else:
+        order = np.arange(N)
+    order = order[: min(N, max_draw)]
+    for i in order:
+        x0, y0 = ptsA[i]
+        x1, y1 = ptsB[i]
+        p0 = (int(round(x0)), int(round(y0)))
+        p1 = (int(round(x1 + offx)), int(round(y1)))
+        cv2.circle(canvas, p0, 2, (0, 255, 0), -1)
+        cv2.circle(canvas, p1, 2, (0, 255, 0), -1)
+        cv2.line(canvas, p0, p1, (0, 200, 255), 1, cv2.LINE_AA)
+    return canvas
+
+
+class TrtRunner:
+    def __init__(self, engine_path):
+        with open(engine_path, "rb") as f:
+            runtime = trt.Runtime(TRT_LOGGER)
+            self.engine = runtime.deserialize_cuda_engine(f.read())
+        self.ctx = self.engine.create_execution_context()
+        self.in0 = "image0"
+        self.in1 = "image1"
+        self.outW = "warp_c"
+        self.outC = "cert_c"
+
+    @torch.inference_mode()
+    def __call__(self, x0: torch.Tensor, x1: torch.Tensor):
+        assert x0.is_cuda and x1.is_cuda
+        B, C, H, W = x0.shape
+        assert (H % 14) == 0 and (W % 14) == 0, "Inputs must be multiples of 14"
+
+        # Set shapes + bind buffers
+        self.ctx.set_input_shape(self.in0, (B, C, H, W))
+        self.ctx.set_input_shape(self.in1, (B, C, H, W))
+        self.ctx.set_tensor_address(self.in0, int(x0.data_ptr()))
+        self.ctx.set_tensor_address(self.in1, int(x1.data_ptr()))
+
+        Ha, Wa = H // 14, W // 14
+        warp_buf = torch.empty((B, Ha, Wa, 2), dtype=torch.float32, device="cuda")
+        cert_buf = torch.empty((B, Ha, Wa), dtype=torch.float32, device="cuda")
+        self.ctx.set_tensor_address(self.outW, int(warp_buf.data_ptr()))
+        self.ctx.set_tensor_address(self.outC, int(cert_buf.data_ptr()))
+
+        self.ctx.execute_async_v3(stream_handle=0)
+        return warp_buf, cert_buf
+
+
+def ransac_filter(pts0, pts1, reproj=3.0, conf=0.999, maxIters=5000):
+    if len(pts0) < 8:
+        return None, np.zeros(len(pts0), dtype=bool)
+    H, mask = cv2.findHomography(
+        pts0,
+        pts1,
+        cv2.RANSAC,
+        ransacReprojThreshold=reproj,
+        confidence=conf,
+        maxIters=maxIters,
+    )
+    inl = (mask.ravel() > 0) if mask is not None else np.zeros(len(pts0), dtype=bool)
+    return H, inl
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--engine", type=str, default="out/matchanything_dense.plan")
+    ap.add_argument("--img0", required=True)
+    ap.add_argument("--img1", required=True)
+    ap.add_argument(
+        "--size", type=int, default=840, help="We will round this up to multiple of 14"
+    )
+    ap.add_argument("--conf_th", type=float, default=0.05)
+    ap.add_argument("--topk", type=int, default=0)
+    ap.add_argument("--no_ransac", action="store_true")
+    ap.add_argument("--out", type=str, default="outputs")
+    args = ap.parse_args()
+
+    x0, img0_bgr = load_rgb_tensor(args.img0, size=args.size)
+    x1, img1_bgr = load_rgb_tensor(args.img1, size=args.size)
+    x0 = x0.cuda()
+    x1 = x1.cuda()
+
+    runner = TrtRunner(args.engine)
+    warp_c, cert_c = runner(x0, x1)  # [1,Ha,Wa,2], [1,Ha,Wa]
+
+    # Build coarse grid for image0
+    _, Ha, Wa, _ = warp_c.shape
+    yy, xx = torch.meshgrid(
+        torch.arange(Ha, device="cuda"), torch.arange(Wa, device="cuda"), indexing="ij"
+    )
+    grid0_c = torch.stack([xx, yy], dim=-1).float()  # [Ha,Wa,2] x,y on coarse grid
+
+    # Flatten matches
+    k0_c = grid0_c.view(-1, 2).cpu().numpy()
+    k1_c = warp_c[0].view(-1, 2).detach().cpu().numpy()
+    mconf = cert_c[0].reshape(-1).detach().cpu().numpy()
+
+    # Host-side filtering (like HF/RoMa)
+    keep = np.isfinite(mconf) & (mconf >= args.conf_th)
+    if args.topk and keep.sum() > args.topk:
+        order = np.argsort(np.nan_to_num(mconf[keep], nan=-1.0))[::-1][: args.topk]
+        idx = np.flatnonzero(keep)[order]
+    else:
+        idx = np.flatnonzero(keep)
+
+    # Scale to pixel coordinates (ViT-L/14 → scale=14)
+    scale = 14.0
+    k0 = k0_c[idx] * scale
+    k1 = k1_c[idx] * scale
+    scores = mconf[idx]
+
+    print(f"Kept {len(scores)} matches @ conf_th={args.conf_th}")
+    if not args.no_ransac and len(scores) >= 8:
+        Hm, inl = ransac_filter(k0, k1)
+        if inl is not None and inl.any():
+            print(f"RANSAC inliers: {inl.sum()}/{len(inl)}")
+            k0, k1, scores = k0[inl], k1[inl], scores[inl]
+    else:
+        k0_r, k1_r, s_r = k0, k1, scores
+    if args.no_ransac or len(scores) < 8:
+        k0_r, k1_r, s_r = k0, k1, scores
+
+    vis = draw_matches_side_by_side(
+        img0_bgr, img1_bgr, k0_r, k1_r, conf=s_r, max_draw=1000
+    )
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem0 = Path(args.img0).stem
+    stem1 = Path(args.img1).stem
+    out_png = out_dir / f"vis_{stem0}_vs_{stem1}.png"
+    ok = cv2.imwrite(str(out_png), vis)
+    print(f"[SAVE] {out_png} (ok={ok})")
+
+
+if __name__ == "__main__":
+    main()

--- a/Convertion_Tensorrt_new/run_trt_dense_dynamic.py
+++ b/Convertion_Tensorrt_new/run_trt_dense_dynamic.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+import numpy as np
+import cv2
+import torch
+import tensorrt as trt
+
+TRT_LOGGER = trt.Logger(trt.Logger.INFO)
+
+
+def load_rgb_tensor(path, size=None):
+    img_bgr = cv2.imread(str(path), cv2.IMREAD_COLOR)
+    if img_bgr is None:
+        raise FileNotFoundError(path)
+    if size:
+        img_bgr = cv2.resize(img_bgr, (size, size), interpolation=cv2.INTER_LANCZOS4)
+    img_rgb = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0
+    t = (
+        torch.from_numpy(np.transpose(img_rgb, (2, 0, 1))[None, ...])
+        .contiguous()
+        .float()
+    )
+    return t, img_bgr
+
+
+def draw_matches_side_by_side(imgA, imgB, ptsA, ptsB, conf=None, max_draw=1000):
+    A = imgA.copy()
+    B = imgB.copy()
+    if A.ndim == 2:
+        A = cv2.cvtColor(A, cv2.COLOR_GRAY2BGR)
+    if B.ndim == 2:
+        B = cv2.cvtColor(B, cv2.COLOR_GRAY2BGR)
+    H = max(A.shape[0], B.shape[0])
+    canvas = np.zeros((H, A.shape[1] + B.shape[1], 3), dtype=np.uint8)
+    canvas[: A.shape[0], : A.shape[1]] = A
+    canvas[: B.shape[0], A.shape[1] : A.shape[1] + B.shape[1]] = B
+    offx = A.shape[1]
+    N = ptsA.shape[0]
+    order = (
+        np.argsort(np.nan_to_num(conf, nan=-1.0))[::-1]
+        if conf is not None
+        else np.arange(N)
+    )
+    order = order[: min(N, max_draw)]
+    for i in order:
+        x0, y0 = ptsA[i]
+        x1, y1 = ptsB[i]
+        p0 = (int(round(x0)), int(round(y0)))
+        p1 = (int(round(x1 + offx)), int(round(y1)))
+        cv2.circle(canvas, p0, 2, (0, 255, 0), -1)
+        cv2.circle(canvas, p1, 2, (0, 255, 0), -1)
+        cv2.line(canvas, p0, p1, (0, 200, 255), 1, cv2.LINE_AA)
+    return canvas
+
+
+class TrtRunner:
+    def __init__(self, engine_path):
+        with open(engine_path, "rb") as f:
+            runtime = trt.Runtime(TRT_LOGGER)
+            self.engine = runtime.deserialize_cuda_engine(f.read())
+        self.ctx = self.engine.create_execution_context()
+        self.in0 = "image0"
+        self.in1 = "image1"
+        self.outW = "warp_c"
+        self.outC = "cert_c"
+        self.outM = "valid_mask"
+        self.outS = "coarse_stride"
+
+    @torch.inference_mode()
+    def __call__(self, x0: torch.Tensor, x1: torch.Tensor):
+        assert x0.is_cuda and x1.is_cuda
+        B, C, H, W = x0.shape
+        self.ctx.set_input_shape(self.in0, (B, C, H, W))
+        self.ctx.set_input_shape(self.in1, (B, C, H, W))
+        self.ctx.set_tensor_address(self.in0, int(x0.data_ptr()))
+        self.ctx.set_tensor_address(self.in1, int(x1.data_ptr()))
+
+        shapeW = self.ctx.get_tensor_shape(self.outW)  # (B,Ha,Wa,2)
+        shapeC = self.ctx.get_tensor_shape(self.outC)  # (B,Ha,Wa)
+        shapeM = self.ctx.get_tensor_shape(self.outM)  # (B,Ha,Wa)
+        shapeS = self.ctx.get_tensor_shape(self.outS)  # (1,)
+
+        warp_buf = torch.empty(tuple(shapeW), dtype=torch.float32, device="cuda")
+        cert_buf = torch.empty(tuple(shapeC), dtype=torch.float32, device="cuda")
+        mask_buf = torch.empty(tuple(shapeM), dtype=torch.float32, device="cuda")
+        stridebuf = torch.empty(tuple(shapeS), dtype=torch.float32, device="cuda")
+        self.ctx.set_tensor_address(self.outW, int(warp_buf.data_ptr()))
+        self.ctx.set_tensor_address(self.outC, int(cert_buf.data_ptr()))
+        self.ctx.set_tensor_address(self.outM, int(mask_buf.data_ptr()))
+        self.ctx.set_tensor_address(self.outS, int(stridebuf.data_ptr()))
+
+        self.ctx.execute_async_v3(stream_handle=0)
+        return warp_buf, cert_buf, mask_buf, stridebuf
+
+
+def ransac_filter(pts0, pts1, reproj=3.0, conf=0.999, maxIters=5000):
+    if len(pts0) < 8:
+        return None, np.zeros(len(pts0), dtype=bool)
+    H, mask = cv2.findHomography(
+        pts0,
+        pts1,
+        cv2.RANSAC,
+        ransacReprojThreshold=reproj,
+        confidence=conf,
+        maxIters=maxIters,
+    )
+    inl = (mask.ravel() > 0) if mask is not None else np.zeros(len(pts0), dtype=bool)
+    return H, inl
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--engine", type=str, default="out/matchanything_dense_dynamic.plan"
+    )
+    ap.add_argument("--img0", required=True)
+    ap.add_argument("--img1", required=True)
+    ap.add_argument(
+        "--size", type=int, default=0, help="Optional square resize. 0=keep originals."
+    )
+    ap.add_argument("--conf_th", type=float, default=0.05)
+    ap.add_argument("--topk", type=int, default=0)
+    ap.add_argument("--no_ransac", action="store_true")
+    ap.add_argument("--out", type=str, default="outputs")
+    args = ap.parse_args()
+
+    x0, im0 = load_rgb_tensor(args.img0, size=(args.size or None))
+    x1, im1 = load_rgb_tensor(args.img1, size=(args.size or None))
+    x0 = x0.cuda()
+    x1 = x1.cuda()
+
+    runner = TrtRunner(args.engine)
+    warp_c, cert_c, valid_c, stride_t = runner(
+        x0, x1
+    )  # [1,Ha,Wa,2], [1,Ha,Wa], [1,Ha,Wa], [1]
+
+    # Build coarse grid for image0
+    _, Ha, Wa, _ = warp_c.shape
+    yy, xx = torch.meshgrid(
+        torch.arange(Ha, device="cuda"), torch.arange(Wa, device="cuda"), indexing="ij"
+    )
+    grid0_c = torch.stack([xx, yy], dim=-1).float()  # [Ha,Wa,2]
+
+    # Flatten + host filtering using mask + conf_th (+topK)
+    k0_c = grid0_c.view(-1, 2).cpu().numpy()
+    k1_c = warp_c[0].view(-1, 2).detach().cpu().numpy()
+    mconf = cert_c[0].reshape(-1).detach().cpu().numpy()
+    mval = valid_c[0].reshape(-1).detach().cpu().numpy()
+
+    keep = (mval > 0.5) & np.isfinite(mconf) & (mconf >= args.conf_th)
+    idx = np.flatnonzero(keep)
+    if args.topk and idx.size > args.topk:
+        order = np.argsort(np.nan_to_num(mconf[idx], nan=-1.0))[::-1][: args.topk]
+        idx = idx[order]
+
+    stride = float(stride_t[0].item())
+    k0 = k0_c[idx] * stride
+    k1 = k1_c[idx] * stride
+    scores = mconf[idx]
+
+    print(f"Kept {len(scores)} matches @ conf_th={args.conf_th}")
+    if not args.no_ransac and len(scores) >= 8:
+        Hm, inl = ransac_filter(k0, k1)
+        if inl is not None and inl.any():
+            print(f"RANSAC inliers: {inl.sum()}/{len(inl)}")
+            k0, k1, scores = k0[inl], k1[inl], scores[inl]
+
+    vis = draw_matches_side_by_side(im0, im1, k0, k1, conf=scores, max_draw=1000)
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem0 = Path(args.img0).stem
+    stem1 = Path(args.img1).stem
+    out_png = out_dir / f"vis_{stem0}_vs_{stem1}.png"
+    ok = cv2.imwrite(str(out_png), vis)
+    print(f"[SAVE] {out_png} (ok={ok})")
+
+
+if __name__ == "__main__":
+    main()

--- a/Convertion_Tensorrt_new/verify_onnx_dense.py
+++ b/Convertion_Tensorrt_new/verify_onnx_dense.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import cv2
+import numpy as np
+import onnxruntime as ort
+
+
+def ceil_mul14(x):
+    return ((x + 13) // 14) * 14
+
+
+def load_rgb(path, size=None):
+    img = cv2.imread(path, cv2.IMREAD_COLOR)
+    if size is not None:
+        s = ceil_mul14(size)
+        img = cv2.resize(img, (s, s), interpolation=cv2.INTER_LANCZOS4)
+    rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0
+    x = np.transpose(rgb[None, ...], (0, 3, 1, 2)).astype(np.float32)
+    return x, img
+
+
+sess = ort.InferenceSession(
+    "out/matchanything_dense.onnx", providers=["CPUExecutionProvider"]
+)
+in0, in1 = sess.get_inputs()[0].name, sess.get_inputs()[1].name
+outW, outC = sess.get_outputs()[0].name, sess.get_outputs()[1].name
+
+x0, im0 = load_rgb("IMG_A.jpg", size=840)
+x1, im1 = load_rgb("IMG_B.jpg", size=840)
+warp_c, cert_c = sess.run([outW, outC], {in0: x0, in1: x1})
+print("warp_c:", warp_c.shape, "cert_c:", cert_c.shape)


### PR DESCRIPTION
## Summary
- introduce tools to build hybrid checkpoints and diagnose weight mapping
- provide standalone test suite for unified weight loader
- keep earlier dynamic TensorRT export and runner utilities
- add scripts for externalizing ONNX weights and fixing DINOv2 block names

## Testing
- `pre-commit run --files Convertion_Tensorrt/fix_onnx_export.py Convertion_Tensorrt/fix_onnx_external.py Convertion_Tensorrt/fixed_weight_adapter.py`

------
https://chatgpt.com/codex/tasks/task_e_68c2a7d349448322a74722dee8940701