### PR TITLE
Refactor TensorRT export pipeline with canonical DINOv2 support

### DIFF
--- a/Convertion_Tensorrt/accurate_matchanything_trt.py
+++ b/Convertion_Tensorrt/accurate_matchanything_trt.py
@@ -1,459 +1,67 @@
 #!/usr/bin/env python3
-"""
-Accurate MatchAnything TensorRT implementation that matches the original exactly.
-This version replicates the exact preprocessing and postprocessing pipeline.
-"""
-
-import numpy as np
+"""Minimal MatchAnything model for TensorRT export.
+Returns dense warp and certainty maps matching RoMa's interface."""
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
-from typing import Dict, Tuple, Optional
-import cv2
-import PIL
-from PIL import Image
-from pathlib import Path
-import inspect
-import os
-
-# ONNX utilities for export
-import onnx
-
-try:  # pragma: no cover - compatibility shim
-    from onnx import external_data_utils  # type: ignore
-except ImportError:  # pragma: no cover
-    from onnx import external_data_helper as external_data_utils  # type: ignore
 
 from encoders_trt_full import CNNandDinov2TRT
 from gp_trt import GPMatchEncoderTRT
 
-
 class AccurateMatchAnythingTRT(nn.Module):
-    """
-    Accurate TensorRT implementation that matches the original MatchAnything exactly.
-    Includes the full preprocessing and postprocessing pipeline.
-    """
-
-    def __init__(
-        self,
-        model_name: str = "matchanything_roma",
-        img_resize: int = 832,
-        match_threshold: float = 0.1,
-        amp: bool = False,
-    ):
+    def __init__(self, amp: bool = False):
         super().__init__()
-        self.model_name = model_name
-        self.img_resize = img_resize
-        self.match_threshold = match_threshold
-        self.amp = amp
+        self.encoder = CNNandDinov2TRT(amp=amp)
+        self.matcher = GPMatchEncoderTRT(beta=10.0)
 
-        if model_name == "matchanything_roma":
-            # Use our TensorRT-optimized ROMA implementation
-            self.encoder = CNNandDinov2TRT(amp=amp)
-            self.matcher = GPMatchEncoderTRT(beta=10.0)
-        else:
-            raise NotImplementedError(
-                f"Model {model_name} not implemented for TensorRT"
-            )
+    def forward(self, image0: torch.Tensor, image1: torch.Tensor):
+        feat0 = self.encoder(image0)["coarse"]
+        feat1 = self.encoder(image1)["coarse"]
+        warp_c, cert_c = self.matcher(feat0, feat1)
+        return warp_c, cert_c
 
-    def process_resize(
-        self,
-        w: int,
-        h: int,
-        resize: Optional[int] = None,
-        df: Optional[int] = None,
-        resize_no_larger_than: bool = False,
-    ) -> Tuple[int, int]:
-        """Exact copy of the original process_resize function"""
-        if resize is not None:
-            if resize_no_larger_than and (max(h, w) <= resize):
-                w_new, h_new = w, h
-            else:
-                scale = resize / max(h, w)
-                w_new, h_new = int(round(w * scale)), int(round(h * scale))
-        else:
-            w_new, h_new = w, h
-
-        if df is not None:
-            w_new, h_new = map(lambda x: int(x // df * df), [w_new, h_new])
-        return w_new, h_new
-
-    def resize_image(
-        self, image: np.ndarray, size: Tuple[int, int], interp: str
-    ) -> np.ndarray:
-        """Exact copy of the original resize_image function"""
-        if interp.startswith("cv2_"):
-            interp = getattr(cv2, "INTER_" + interp[len("cv2_") :].upper())
-            h, w = image.shape[:2]
-            if interp == cv2.INTER_AREA and (w < size[0] or h < size[1]):
-                interp = cv2.INTER_LINEAR
-            resized = cv2.resize(image, size, interpolation=interp)
-        elif interp.startswith("pil_"):
-            interp = getattr(PIL.Image, interp[len("pil_") :].upper())
-            resized = PIL.Image.fromarray(image.astype(np.uint8))
-            resized = resized.resize(size, resample=interp)
-            resized = np.asarray(resized, dtype=image.dtype)
-        else:
-            raise ValueError(f"Unknown interpolation {interp}.")
-        return resized
-
-    def pad_bottom_right(self, inp: np.ndarray, pad_size: int, ret_mask: bool = False):
-        """Exact copy of the original pad_bottom_right function"""
-        assert isinstance(pad_size, int) and pad_size >= max(
-            inp.shape[-2:]
-        ), f"{pad_size} < {max(inp.shape[-2:])}"
-        mask = None
-        if inp.ndim == 2:
-            padded = np.zeros((pad_size, pad_size), dtype=inp.dtype)
-            padded[: inp.shape[0], : inp.shape[1]] = inp
-            if ret_mask:
-                mask = np.zeros((pad_size, pad_size), dtype=bool)
-                mask[: inp.shape[0], : inp.shape[1]] = True
-        elif inp.ndim == 3:
-            padded = np.zeros((inp.shape[0], pad_size, pad_size), dtype=inp.dtype)
-            padded[:, : inp.shape[1], : inp.shape[2]] = inp
-            if ret_mask:
-                mask = np.zeros((inp.shape[0], pad_size, pad_size), dtype=bool)
-                mask[:, : inp.shape[1], : inp.shape[2]] = True
-            mask = mask[0]
-        else:
-            raise NotImplementedError()
-        return padded, mask
-
-    def resize_with_padding(
-        self,
-        img: np.ndarray,
-        resize: Optional[int] = None,
-        df: int = 8,
-        padding: bool = True,
-    ):
-        """Exact copy of the original resize function"""
-        w, h = img.shape[1], img.shape[0]
-        w_new, h_new = self.process_resize(
-            w, h, resize=resize, df=df, resize_no_larger_than=False
-        )
-        img_new = self.resize_image(img, (w_new, h_new), interp="pil_LANCZOS").astype(
-            "float32"
-        )
-        h_scale, w_scale = (
-            img.shape[0] / img_new.shape[0],
-            img.shape[1] / img_new.shape[1],
-        )
-        mask = None
-        if padding:
-            img_new, mask = self.pad_bottom_right(
-                img_new, max(h_new, w_new), ret_mask=True
-            )
-        return img_new, [h_scale, w_scale], mask
-
-    def preprocess_images(
-        self, img0_rgb: torch.Tensor, img1_rgb: torch.Tensor
-    ) -> Dict[str, torch.Tensor]:
-        """
-        Exact preprocessing pipeline matching the original implementation.
-        Input: RGB images as tensors [B, C, H, W] in range [0, 1]
-        """
-        # Convert to numpy and scale to [0, 255]
-        img0 = img0_rgb.cpu().numpy().squeeze() * 255
-        img1 = img1_rgb.cpu().numpy().squeeze() * 255
-        img0 = img0.transpose(1, 2, 0).astype("uint8")
-        img1 = img1.transpose(1, 2, 0).astype("uint8")
-
-        # Get original image sizes
-        img0_size = np.array(img0.shape[:2])
-        img1_size = np.array(img1.shape[:2])
-
-        # Convert to grayscale
-        img0_gray = np.array(Image.fromarray(img0).convert("L"))
-        img1_gray = np.array(Image.fromarray(img1).convert("L"))
-
-        # Resize with padding (df=14 to ensure multiples of 14, not 32!)
-        (img0_gray, hw0_new, mask0) = self.resize_with_padding(img0_gray, df=14)
-        (img1_gray, hw1_new, mask1) = self.resize_with_padding(img1_gray, df=14)
-
-        # Convert to tensors
-        img0_tensor = torch.from_numpy(img0_gray)[None][None] / 255.0
-        img1_tensor = torch.from_numpy(img1_gray)[None][None] / 255.0
-
-        batch = {
-            "image0": img0_tensor,
-            "image1": img1_tensor,
-            "image0_rgb_origin": img0_rgb,
-            "image1_rgb_origin": img1_rgb,
-            "origin_img_size0": torch.from_numpy(img0_size)[None],
-            "origin_img_size1": torch.from_numpy(img1_size)[None],
-            "hw0_new": hw0_new,
-            "hw1_new": hw1_new,
-        }
-
-        # Handle masks if present
-        if mask0 is not None:
-            mask0 = torch.from_numpy(mask0)
-            mask1 = torch.from_numpy(mask1)
-            # Downsample masks by factor of 8 (to match coarse level)
-            ts_mask_0, ts_mask_1 = F.interpolate(
-                torch.stack([mask0, mask1], dim=0)[None].float(),
-                scale_factor=0.125,
-                mode="nearest",
-                recompute_scale_factor=False,
-            )[0].bool()
-            batch.update({"mask0": ts_mask_0[None], "mask1": ts_mask_1[None]})
-
-        return batch
-
-    def forward(
-        self, image0: torch.Tensor, image1: torch.Tensor
-    ) -> Dict[str, torch.Tensor]:
-        """
-        Forward pass that exactly matches the original MatchAnything pipeline.
-
-        Args:
-            image0: RGB image tensor [B, C, H, W] in range [0, 1]
-            image1: RGB image tensor [B, C, H, W] in range [0, 1]
-
-        Returns:
-            Dictionary with keypoints0, keypoints1, and mconf (confidence scores)
-        """
-        device = image0.device
-        B, C, H, W = image0.shape
-
-        # For ONNX export, use simplified preprocessing
-        # Convert RGB to grayscale (simple average)
-        img0_gray = (
-            0.299 * image0[:, 0:1] + 0.587 * image0[:, 1:2] + 0.114 * image0[:, 2:3]
-        )
-        img1_gray = (
-            0.299 * image1[:, 0:1] + 0.587 * image1[:, 1:2] + 0.114 * image1[:, 2:3]
-        )
-
-        # Get features at coarse level (1/16 resolution for DINOv2)
-        feat0_dict = self.encoder(img0_gray)
-        feat1_dict = self.encoder(img1_gray)
-
-        feat0_c = feat0_dict["coarse"]  # [B, C, H/16, W/16]
-        feat1_c = feat1_dict["coarse"]  # [B, C, H/16, W/16]
-
-        # Coarse matching using our GP matcher
-        warp_c, cert_c = self.matcher(feat0_c, feat1_c)  # [B,Ha,Wa,2], [B,Ha,Wa]
-
-        # Apply confidence threshold
-        conf_mask = cert_c > self.match_threshold
-
-        # Extract matches above threshold
-        B, Ha, Wa = cert_c.shape
-
-        # Get coordinates of confident matches
-        conf_indices = torch.nonzero(conf_mask, as_tuple=False)  # [N, 3] (batch, y, x)
-
-        # Extract match coordinates and confidences. When no matches are found
-        # we return empty tensors that still depend on the network outputs to
-        # keep ONNX export graphs connected to the inputs.
-        if conf_indices.shape[0] == 0:
-            batch_idx = torch.zeros(0, dtype=torch.long, device=device)
-            y_coords = torch.zeros(0, dtype=torch.long, device=device)
-            x_coords = torch.zeros(0, dtype=torch.long, device=device)
-            mkpts0_c = warp_c.view(-1, 2)[0:0]
-            mkpts1_c = warp_c.view(-1, 2)[0:0]
-            mconf = cert_c.view(-1)[0:0]
-        else:
-            batch_idx = conf_indices[:, 0]
-            y_coords = conf_indices[:, 1]
-            x_coords = conf_indices[:, 2]
-            mkpts0_c = torch.stack(
-                [x_coords.float(), y_coords.float()], dim=1
-            )  # [N, 2]
-            mkpts1_c = warp_c[batch_idx, y_coords, x_coords]  # [N, 2]
-            mconf = cert_c[batch_idx, y_coords, x_coords]  # [N]
-
-        # Convert from coarse coordinates to original image coordinates
-        # Coarse features are at 1/16 resolution due to DINOv2 downsampling
-        scale_factor = 16.0
-
-        # Scale to full resolution
-        mkpts0_f = mkpts0_c * scale_factor
-        mkpts1_f = mkpts1_c * scale_factor
-
-        return {
-            "keypoints0": mkpts0_f,
-            "keypoints1": mkpts1_f,
-            "mconf": mconf,
-        }
-
-
-class AccurateMatchAnythingWrapper:
-    """
-    Wrapper that provides the exact same interface as the original MatchAnything matcher.
-    This ensures perfect compatibility with existing code.
-    """
-
-    def __init__(self, conf: Dict):
-        self.conf = conf
-        self.model = AccurateMatchAnythingTRT(
-            model_name=conf["model_name"],
-            img_resize=conf.get("img_resize", 832),
-            match_threshold=conf.get("match_threshold", 0.1),
-            amp=conf.get("amp", False),
-        )
-        self.model.eval()
-
-    def __call__(self, data: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
-        """
-        Process images and return matches in the exact same format as original.
-
-        Args:
-            data: Dictionary containing 'image0' and 'image1' tensors
-
-        Returns:
-            Dictionary with 'mkpts0_f', 'mkpts1_f', and 'mconf'
-        """
-        with torch.no_grad():
-            result = self.model(data["image0"], data["image1"])
-
-            # Return in the exact format expected by the original code
-            return {
-                "mkpts0_f": result["keypoints0"],
-                "mkpts1_f": result["keypoints1"],
-                "mconf": result["mconf"],
-            }
-
-
-# Export function for ONNX conversion
-def export_accurate_matchanything_onnx(
-    onnx_path: str,
-    model_name: str = "matchanything_roma",
-    H: int = 832,
-    W: int = 832,
-    match_threshold: float = 0.1,
-    ckpt: Optional[str] = None,
-):
-    """
-    Export the accurate MatchAnything model to ONNX format.
-    """
+def export_accurate_matchanything_onnx(model: nn.Module, onnx_path: str, H: int = 840, W: int = 840):
+    """Export the given model to ONNX format."""
     device = "cpu"
-    model = (
-        AccurateMatchAnythingTRT(
-            model_name=model_name,
-            match_threshold=match_threshold,
-            amp=False,  # Use FP32 for ONNX export
-        )
-        .to(device)
-        .eval()
-    )
-
-    # Load checkpoint if provided
-    if ckpt:
-        print(f"[CKPT] Loading checkpoint: {ckpt}")
-
-        # If checkpoint doesn't exist but we have a default path, try to download
-        if not os.path.exists(ckpt):
-            print(f"[CKPT] Checkpoint not found at {ckpt}")
-            try:
-                from download_weights import download_matchanything_weights
-
-                print("[CKPT] Attempting to download MatchAnything weights...")
-                ckpt = download_matchanything_weights(
-                    output_dir=os.path.dirname(ckpt), force_download=False
-                )
-            except Exception as e:
-                print(f"[CKPT] Failed to download weights: {e}")
-                print("[INFO] Proceeding with random initialization...")
-                ckpt = None
-
-        if ckpt and os.path.exists(ckpt):
-            try:
-                from improved_weight_adapter import apply_improved_mapping
-
-                # Map checkpoint keys to model keys and load the weights
-                model_state = model.state_dict()
-                loadable = apply_improved_mapping(ckpt, model_state)
-                model.load_state_dict(loadable, strict=False)
-
-                if len(loadable) == 0:
-                    print("[WARNING] No weights were loaded from checkpoint!")
-                    print("[INFO] This might be due to architecture mismatch.")
-
-                    # Try direct loading as fallback
-                    print("[INFO] Attempting direct checkpoint loading...")
-                    checkpoint = torch.load(ckpt, map_location="cpu")
-                    state_dict = checkpoint.get("state_dict", checkpoint)
-
-                    missing, unexpected = model.load_state_dict(
-                        state_dict, strict=False
-                    )
-                    print(
-                        f"[INFO] Direct load: {len(state_dict) - len(missing)} loaded, {len(missing)} missing, {len(unexpected)} unexpected"
-                    )
-
-                    if len(missing) < len(state_dict):
-                        print("[SUCCESS] Some weights loaded via direct method")
-                    else:
-                        print(
-                            "[INFO] Proceeding with random initialization for testing..."
-                        )
-                else:
-                    print(
-                        f"[SUCCESS] Loaded {len(loadable)} weight tensors from checkpoint"
-                    )
-            except Exception as e:
-                print(f"[ERROR] Failed to load checkpoint: {e}")
-                print("[INFO] Proceeding with random initialization for testing...")
-    else:
-        print("[INFO] No checkpoint provided, using random initialization")
-
-    # Create dummy inputs
+    model = model.to(device).eval()
+    x0 = torch.rand(1, 3, H, W, device=device)
     x1 = torch.rand(1, 3, H, W, device=device)
-    x2 = torch.rand(1, 3, H, W, device=device)
 
-    # Test forward pass
-    with torch.no_grad():
-        result = model(x1, x2)
-        print("Dry run OK:")
-        print(f"  keypoints0: {result['keypoints0'].shape}")
-        print(f"  keypoints1: {result['keypoints1'].shape}")
-        print(f"  mconf: {result['mconf'].shape}")
-
-    # Export to ONNX with dynamic axes
     dynamic_axes = {
         "image0": {0: "B", 2: "H", 3: "W"},
         "image1": {0: "B", 2: "H", 3: "W"},
-        "keypoints0": {0: "num_matches"},
-        "keypoints1": {0: "num_matches"},
-        "mconf": {0: "num_matches"},
+        "warp_c": {0: "B", 2: "Hc", 3: "Wc"},
+        "cert_c": {0: "B", 2: "Hc", 3: "Wc"},
     }
 
-    os.makedirs(os.path.dirname(onnx_path) or ".", exist_ok=True)
+    import onnx
+    try:
+        from onnx import external_data_utils
+    except ImportError:
+        from onnx import external_data_helper as external_data_utils
 
-    export_kwargs = dict(
+    torch.onnx.export(
+        model,
+        (x0, x1),
+        onnx_path,
         input_names=["image0", "image1"],
-        output_names=["keypoints0", "keypoints1", "mconf"],
+        output_names=["warp_c", "cert_c"],
         dynamic_axes=dynamic_axes,
         opset_version=17,
         do_constant_folding=True,
-        verbose=False,
     )
-    if "use_external_data_format" in inspect.signature(torch.onnx.export).parameters:
-        export_kwargs["use_external_data_format"] = True
 
-    torch.onnx.export(model, (x1, x2), onnx_path, **export_kwargs)
-
-    # Consolidate all weights into a single external data file
     model_proto = onnx.load(onnx_path, load_external_data=True)
     external_data_utils.convert_model_to_external_data(
         model_proto,
         all_tensors_to_one_file=True,
-        location=os.path.basename(onnx_path) + ".data",
+        location=onnx_path + ".data",
         size_threshold=0,
     )
-    onnx.save_model(
-        model_proto,
-        onnx_path,
-        save_as_external_data=True,
-    )
+    onnx.save_model(model_proto, onnx_path, save_as_external_data=True)
 
-    # Remove per-tensor shards created during export
-    out_dir = Path(onnx_path).parent
-    for shard in out_dir.glob("onnx__*"):
+    from pathlib import Path
+    for shard in Path(onnx_path).parent.glob("onnx__*"):
         shard.unlink(missing_ok=True)
 
-    print(f"[ONNX] Exported accurate model -> {onnx_path}")
     return onnx_path
+

--- a/Convertion_Tensorrt/convert_accurate_matchanything.py
+++ b/Convertion_Tensorrt/convert_accurate_matchanything.py
@@ -1,99 +1,112 @@
 #!/usr/bin/env python3
-"""
-Accurate MatchAnything to TensorRT conversion script.
-This version ensures exact match with the original PyTorch implementation.
-"""
-
+"""Convert MatchAnything model to ONNX with deterministic weight loading."""
 import argparse
 import os
+import re
+import warnings
+import torch
 from pathlib import Path
 
-from accurate_matchanything_trt import export_accurate_matchanything_onnx
+from accurate_matchanything_trt import AccurateMatchAnythingTRT, export_accurate_matchanything_onnx
 
+def _strip_prefix(sd, prefix):
+    return {k[len(prefix):]: v for k, v in sd.items() if k.startswith(prefix)}
+
+def load_ma_roma_ckpt_strict(model, ckpt_path, backbone_key="encoder.dino", ckpt_backbone_prefix=("matcher.model.encoder.dino", "encoder.dino")):
+    """Load MatchAnything checkpoint strictly for non-backbone parts."""
+    ckpt = torch.load(ckpt_path, map_location="cpu")
+    state = ckpt.get("state_dict", ckpt)
+    stripped = {}
+    for p in ckpt_backbone_prefix:
+        stripped.update(_strip_prefix(state, p + "."))
+
+    target_sd = model.state_dict()
+    to_load = {}
+    missing_dbg, unexpected_dbg = [], []
+
+    for k, v in state.items():
+        kk = k
+        if kk.startswith("matcher.model."):
+            kk = kk[len("matcher.model."):]
+        if kk.startswith(backbone_key + "."):
+            continue
+        if kk in target_sd and target_sd[kk].shape == v.shape:
+            to_load[kk] = v
+        else:
+            if kk not in target_sd:
+                unexpected_dbg.append(kk)
+            else:
+                missing_dbg.append((kk, v.shape, target_sd[kk].shape))
+
+    msg = model.load_state_dict(to_load, strict=False)
+    if msg.missing_keys:
+        warnings.warn(f"[CKPT non-backbone] Missing keys: {len(msg.missing_keys)} -> e.g. {msg.missing_keys[:5]}")
+    if msg.unexpected_keys:
+        warnings.warn(f"[CKPT non-backbone] Unexpected keys: {len(msg.unexpected_keys)} -> e.g. {msg.unexpected_keys[:5]}")
+    if missing_dbg:
+        warnings.warn(f"[CKPT non-backbone] Shape mismatches: {len(missing_dbg)}")
+
+def load_official_dinov2_backbone(model, backbone_key="encoder.dino", use_timm_first=True):
+    """Fill the DINOv2 backbone with canonical weights."""
+    off = None
+    if use_timm_first:
+        try:
+            import timm
+            m = timm.create_model("vit_large_patch14_dinov2.lvd142m", pretrained=True, num_classes=0, features_only=False)
+            off = m.state_dict()
+        except Exception:
+            off = None
+    if off is None:
+        dinov2 = torch.hub.load('facebookresearch/dinov2', 'dinov2_vitl14')
+        off = dinov2.state_dict()
+
+    tgt_sd = model.state_dict()
+    mapped = {}
+    ok, skip = 0, 0
+    for k, v in off.items():
+        k2 = f"{backbone_key}.{k}"
+        if k2 in tgt_sd and tgt_sd[k2].shape == v.shape:
+            mapped[k2] = v
+            ok += 1
+        else:
+            skip += 1
+
+    msg = model.load_state_dict(mapped, strict=False)
+    if msg.missing_keys or msg.unexpected_keys:
+        warnings.warn(f"[DINOv2 backbone] missing={len(msg.missing_keys)} unexpected={len(msg.unexpected_keys)}")
+    print(f"[DINOv2 backbone] loaded {ok} tensors, skipped {skip} (shape/name mismatch).")
+    return ok
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Convert MatchAnything to TensorRT with exact accuracy"
-    )
-    parser.add_argument(
-        "--onnx",
-        default="Convertion_Tensorrt/out/accurate_matchanything.onnx",
-        help="Output ONNX file path",
-    )
-    parser.add_argument(
-        "--model",
-        choices=["matchanything_roma", "matchanything_eloftr"],
-        default="matchanything_roma",
-        help="Model variant to convert",
-    )
-    parser.add_argument("--H", type=int, default=840, help="Input height")
-    parser.add_argument("--W", type=int, default=840, help="Input width")
-    parser.add_argument(
-        "--match_threshold", type=float, default=0.1, help="Match confidence threshold"
-    )
-    parser.add_argument(
-        "--ckpt", type=str, default=None, help="Path to MatchAnything checkpoint"
-    )
-    parser.add_argument("--verbose", action="store_true", help="Verbose output")
+    ap = argparse.ArgumentParser(description="Convert MatchAnything to ONNX")
+    ap.add_argument("--onnx", default="Convertion_Tensorrt/out/accurate_matchanything.onnx", help="Output ONNX path")
+    ap.add_argument("--H", type=int, default=840)
+    ap.add_argument("--W", type=int, default=840)
+    ap.add_argument("--ckpt", type=str, default=None, help="Path to MatchAnything checkpoint")
+    args = ap.parse_args()
 
-    args = parser.parse_args()
+    os.makedirs(os.path.dirname(args.onnx) or ".", exist_ok=True)
 
-    print("=" * 60)
-    print("ACCURATE MATCHANYTHING TO TENSORRT CONVERSION")
-    print("=" * 60)
-    print(f"Model: {args.model}")
-    print(f"Input size: {args.H}x{args.W}")
-    print(f"Match threshold: {args.match_threshold}")
+    model = AccurateMatchAnythingTRT()
     if args.ckpt:
-        print(f"Checkpoint: {args.ckpt}")
-    print()
+        load_ma_roma_ckpt_strict(model, args.ckpt, backbone_key="encoder.dino")
+    loaded = load_official_dinov2_backbone(model, backbone_key="encoder.dino")
+    assert loaded > 0, "Failed to load any DINOv2 backbone weights"
 
-    # Step 1: Export to ONNX
-    print("Step 1: Exporting to ONNX...")
-    onnx_path = export_accurate_matchanything_onnx(
-        onnx_path=args.onnx,
-        model_name=args.model,
-        H=args.H,
-        W=args.W,
-        match_threshold=args.match_threshold,
-        ckpt=args.ckpt,
-    )
+    onnx_path = export_accurate_matchanything_onnx(model, args.onnx, H=args.H, W=args.W)
+    print(f"[ONNX] Exported accurate model -> {onnx_path}")
 
-    print("\n" + "=" * 60)
-    print("ONNX EXPORT COMPLETE")
-    print("=" * 60)
-    print(f"Output: {onnx_path}")
-
-    # Step 3: Provide TensorRT build commands
-    engine_path = onnx_path.replace(".onnx", ".plan")
-
-    print("\nNext: Build TensorRT engine with trtexec:")
-    print("\nRecommended command:")
+    engine_path = args.onnx.replace(".onnx", ".plan")
+    print("\nNext: build TensorRT engine with trtexec:")
     print("/usr/src/tensorrt/bin/trtexec \\")
-    print(f"    --onnx={onnx_path} \\")
-    print(f"    --saveEngine={engine_path} \\")
-    print("    --fp16 --memPoolSize=workspace:4096M \\")
-    print(
-        f"    --minShapes=image0:1x3x{args.H//2}x{args.W//2},image1:1x3x{args.H//2}x{args.W//2} \\")
-    print(
-        f"    --optShapes=image0:1x3x{args.H}x{args.W},image1:1x3x{args.H}x{args.W} \\")
-    print(
-        f"    --maxShapes=image0:1x3x{args.H*2}x{args.W*2},image1:1x3x{args.H*2}x{args.W*2} \\")
-    print("    --skipInference --verbose")
-
-    print("\nThen run inference:")
-    print("python3 run_accurate_matchanything_trt.py \\")
-    print(f"    --engine {engine_path} \\")
-    print("    --image0 image1.jpg --image1 image2.jpg")
-
-    print("\n" + "=" * 60)
-    print("CONVERSION READY")
-    print("=" * 60)
-    print(
-        "The exported ONNX model maintains exact accuracy with the original PyTorch implementation."
-    )
-    print("All preprocessing and postprocessing steps are preserved.")
-
+    print(f"  --onnx={onnx_path} \\")
+    print(f"  --saveEngine={engine_path} \\")
+    print("  --fp16 --memPoolSize=workspace:4096M \\")
+    print(f"  --minShapes=image0:1x3x{args.H//2}x{args.W//2},image1:1x3x{args.H//2}x{args.W//2} \\")
+    print(f"  --optShapes=image0:1x3x{args.H}x{args.W},image1:1x3x{args.H}x{args.W} \\")
+    print(f"  --maxShapes=image0:1x3x{args.H*2}x{args.W*2},image1:1x3x{args.H*2}x{args.W*2} \\")
+    print("  --skipInference --verbose")
 
 if __name__ == "__main__":
     main()
+

--- a/Convertion_Tensorrt/preprocess.py
+++ b/Convertion_Tensorrt/preprocess.py
@@ -1,0 +1,25 @@
+import math
+import torch
+import numpy as np
+import cv2
+
+def pad_to_multiple(img, multiple=14):
+    h, w = img.shape[-2:]
+    nh = int(math.ceil(h / multiple) * multiple)
+    nw = int(math.ceil(w / multiple) * multiple)
+    pad_h, pad_w = nh - h, nw - w
+    if pad_h == 0 and pad_w == 0:
+        return img, (0, 0, 0, 0)
+    img = torch.nn.functional.pad(img, (0, pad_w, 0, pad_h))
+    return img, (0, pad_w, 0, pad_h)
+
+def preprocess_rgb(image_bchw_float01, multiple=14):
+    img, pads = pad_to_multiple(image_bchw_float01, multiple=multiple)
+    return img, pads
+
+def unpad_like(out, pads):
+    _, pw, _, ph = pads
+    if ph or pw:
+        return out[..., : -ph or None, : -pw or None]
+    return out
+

--- a/Convertion_Tensorrt/verify_parity.py
+++ b/Convertion_Tensorrt/verify_parity.py
@@ -1,0 +1,62 @@
+import argparse
+import numpy as np
+import onnxruntime as ort
+import torch
+from pathlib import Path
+from preprocess import preprocess_rgb, unpad_like
+
+@torch.no_grad()
+def run_pytorch(model, img0, img1):
+    img0, pads0 = preprocess_rgb(img0)
+    img1, pads1 = preprocess_rgb(img1)
+    w0, c0 = model(img0, img1)
+    return unpad_like(w0, pads0), unpad_like(c0, pads0)
+
+def run_onnx(sess, img0, img1):
+    img0, pads0 = preprocess_rgb(img0)
+    img1, pads1 = preprocess_rgb(img1)
+    outs = sess.run(None, {"image0": img0.cpu().numpy(), "image1": img1.cpu().numpy()})
+    warp, cert = [torch.from_numpy(x) for x in outs]
+    return unpad_like(warp, pads0), unpad_like(cert, pads0)
+
+def mae(a, b):
+    return (a - b).abs().mean().item()
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--engine", type=str, default="")
+    ap.add_argument("--onnx", type=str, required=True)
+    ap.add_argument("--images", nargs=2, required=True)
+    args = ap.parse_args()
+
+    def load_img(p):
+        import cv2
+        im = cv2.cvtColor(cv2.imread(p), cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0
+        t = torch.from_numpy(im).permute(2,0,1).unsqueeze(0)
+        return t
+
+    img0 = load_img(args.images[0])
+    img1 = load_img(args.images[1])
+
+    from accurate_matchanything_trt import AccurateMatchAnythingTRT
+    model = AccurateMatchAnythingTRT().eval().cuda() if torch.cuda.is_available() else AccurateMatchAnythingTRT().eval()
+
+    sess = ort.InferenceSession(args.onnx, providers=["CPUExecutionProvider"])
+
+    w_pt, c_pt = run_pytorch(model, img0.clone(), img1.clone())
+    w_ox, c_ox = run_onnx(sess, img0.clone(), img1.clone())
+
+    print("MAE warp:", mae(w_pt, w_ox))
+    print("MAE cert:", mae(c_pt, c_ox))
+
+    H, W = w_pt.shape[-2:]
+    ys = torch.randint(0, H, (512,))
+    xs = torch.randint(0, W, (512,))
+    flow_pt = w_pt[0, :, ys, xs].T
+    flow_ox = w_ox[0, :, ys, xs].T
+    err = (flow_pt - flow_ox).norm(dim=1)
+    print("Pct within 1px:", (err < 1.0).float().mean().item() * 100.0)
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- load official DINOv2 weights deterministically and separate non-backbone params
- simplify MatchAnything TRT model to output dense warp & certainty maps
- add host-side preprocessing, TensorRT runner updates, and ONNX parity check

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'imcui')*
- `python Convertion_Tensorrt/convert_accurate_matchanything.py --onnx Convertion_Tensorrt/out/accurate_matchanything.onnx --H 420 --W 420` *(fails: urllib.error.URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_68c68c2bb3e88322b03b818b834f8fc9